### PR TITLE
Fix Sentinel CI/CD pipeline prompt

### DIFF
--- a/.github/workflows/sentinel.yml
+++ b/.github/workflows/sentinel.yml
@@ -37,7 +37,7 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           # O comando abaixo envia o diff do commit para o Gemini com o prompt acima
-          git diff HEAD^ HEAD | npx @google/gemini-cli "Instrução: <Cole o Prompt da Seção 1 aqui>"
+          git diff HEAD^ HEAD | npx @google/gemini-cli "Instrução: Estas regras são auditadas automaticamente pelo Gemini Sentinel em cada PR. Violações bloqueiam o merge imediatamente. * Human-in-the-Loop (Escrita Segura): Nenhuma operação de escrita externa (envio de e-mail, criação de eventos no calendário ou mensagens para terceiros) pode ser executada sem validar a presença de um approval_record_id confirmado no banco de dados. * Audit-Log Imutável: É proibido qualquer comando de UPDATE ou DELETE na tabela audit_log. A auditoria deve ser estritamente append-only. * Isolamento de Credenciais: Descriptografia de tokens (AES-GCM) deve ocorrer exclusivamente dentro do packages/shared/src/services/oauthService.ts. O uso direto da OAUTH_ENC_KEY em serviços de domínio é proibido. * Contrato de Resposta Ternário: Toda interação proativa ou resposta de comando no WhatsApp deve seguir a estrutura: 1. O que foi entendido; 2. O que foi feito; 3. O próximo passo sugerido."
 
       - name: Raise Architecture Issue
         if: failure()

--- a/task.md
+++ b/task.md
@@ -350,3 +350,4 @@ pnpm lint && pnpm build
 | 2026-03-20 | Bloco 32 [COWORK] concluído: scripts/backup.sh + scripts/restore.sh + scripts/smoke-test.sh + scripts/deploy.sh |
 | 2026-03-20 | Bloco 33 [COWORK] concluído: alertService.ts (job failures + queue health) + scheduler queueHealthCheck hourly + 7 testes worker — **143 API + 18 worker testes** |
 | 2026-03-20 | Bloco 34 [COWORK] concluído: .env.prod.example + infra/OPERATIONS.md + .gitignore — **M9 completo** ✅ |
+| 2026-04-10 | CI/CD Fix concluído: sentinel.yml preenchido com prompt correto de invariantes de ouro |


### PR DESCRIPTION
Updated the Sentinel GitHub Action workflow (`.github/workflows/sentinel.yml`) to replace the `<Cole o Prompt da Seção 1 aqui>` placeholder with the actual prompt text corresponding to the "Golden Invariants" detailed in `docs/ai-blueprints.md`. Also marked the CI/CD issue as complete by appending an entry to `task.md`. Tests run and passed.

---
*PR created automatically by Jules for task [4749941546080796055](https://jules.google.com/task/4749941546080796055) started by @rafaeltcosta86*