### PR TITLE
fix(parser): reconhecer linguagem natural de áudio para SEND_TO

### DIFF
--- a/apps/api/src/lib/__tests__/commandParser.test.ts
+++ b/apps/api/src/lib/__tests__/commandParser.test.ts
@@ -86,6 +86,30 @@ describe('parseCommand', () => {
     });
   });
 
+  describe('SEND_TO', () => {
+    it('estrutura clássica: manda para <nome>: <msg>', () => {
+      expect(parseCommand('manda para amanda: oi')).toEqual({
+        intent: 'SEND_TO',
+        args: { contactName: 'amanda', message: 'oi' },
+      });
+    });
+
+    it('linguagem natural de áudio: manda <msg> pra <nome>', () => {
+      expect(parseCommand('Manda um oi pra Amanda.')).toEqual({
+        intent: 'SEND_TO',
+        args: { contactName: 'Amanda', message: 'um oi' },
+      });
+    });
+
+    it('linguagem natural: manda um abraço para João', () => {
+      expect(parseCommand('manda um abraço para João')).toEqual({
+        intent: 'SEND_TO',
+        args: { contactName: 'João', message: 'um abraço' },
+      });
+    });
+
+  });
+
   describe('CREATE_TASK', () => {
     it('returns CREATE_TASK intent with rawText for plain text', () => {
       expect(parseCommand('comprar leite')).toEqual({

--- a/apps/api/src/lib/commandParser.ts
+++ b/apps/api/src/lib/commandParser.ts
@@ -105,6 +105,19 @@ export function parseCommand(text: string): ParsedCommand {
     };
   }
 
+  // Linguagem natural de áudio: "manda <msg> pra/para/pro <nome>[.]"
+  // ex: "Manda um oi pra Amanda." / "manda um abraço para João"
+  const sendToNaturalMatch = /^manda(?:r)?\s+(.+?)\s+(?:pra|para|pro)\s+([^\s,.:]+)[.,]?$/i.exec(trimmed);
+  if (sendToNaturalMatch) {
+    return {
+      intent: 'SEND_TO',
+      args: {
+        contactName: sendToNaturalMatch[2].trim(),
+        message: sendToNaturalMatch[1].trim(),
+      },
+    };
+  }
+
   // manda para <nome>: <msg> | fala com <nome> que <msg> | avisa <nome>: <msg>
   const sendToMatch = /^(?:manda(?:r)? (?:para|pro|pra)|fala com|avisa) (.+?)(?::|,| que | dizendo ) (.+)$/i.exec(trimmed);
   if (sendToMatch) {


### PR DESCRIPTION
## Summary

- Adiciona regex para capturar `manda <msg> pra/para/pro <nome>[.]`
- Necessário porque o Whisper transcreve voz em linguagem natural, não no formato estruturado `manda para <nome>: <msg>`
- 192 testes passando

## Test plan

- [ ] Mandar áudio "Manda um oi pra Amanda" e verificar preview SEND_TO
- [ ] Confirmar que a estrutura clássica "manda para Amanda: oi" continua funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)