### PR TITLE
fix(send-to): resolver contato no DB antes do env var

### DIFF
--- a/apps/api/src/routes/__tests__/webhook.audio.test.ts
+++ b/apps/api/src/routes/__tests__/webhook.audio.test.ts
@@ -26,6 +26,13 @@ vi.mock('../../lib/redis', () => ({
   default: { set: vi.fn(), get: vi.fn(), del: vi.fn() },
 }));
 
+vi.mock('../../lib/contactService', () => ({
+  findByAlias: vi.fn().mockResolvedValue(null),
+  findByName: vi.fn().mockResolvedValue(null),
+  addAlias: vi.fn(),
+  createContact: vi.fn(),
+}));
+
 import webhookRouter from '../webhook';
 import { transcribeAudio } from '../../lib/whisperService';
 import { classifyIntent, suggestAction } from '../../lib/llmService';

--- a/apps/api/src/routes/__tests__/webhook.test.ts
+++ b/apps/api/src/routes/__tests__/webhook.test.ts
@@ -37,7 +37,7 @@ vi.mock('../../lib/emailService', () => ({
 
 vi.mock('../../lib/contactService', () => ({
   findByAlias: vi.fn(),
-  findByName: vi.fn(),
+  findByName: vi.fn().mockResolvedValue(null),
   addAlias: vi.fn(),
 }));
 
@@ -55,6 +55,7 @@ import { getEmailSummary } from '../../lib/emailService';
 import { sendWhatsApp } from '../../lib/nanoclawClient';
 import prisma from '../../lib/prisma';
 import { findByAlias, findByName, addAlias } from '../../lib/contactService';
+// findByName is mocked to return null by default (env var contacts used instead)
 import { classifyIntent } from '../../lib/llmService';
 
 const app = express();

--- a/apps/api/src/routes/webhook.ts
+++ b/apps/api/src/routes/webhook.ts
@@ -7,7 +7,7 @@ import { addDays, nextMonday } from 'date-fns';
 import { utcToZonedTime } from 'date-fns-tz';
 import { getEmailSummary } from '../lib/emailService';
 import { getOrCreateProfile } from '../lib/userModel';
-import { findByAlias, addAlias, createContact } from '../lib/contactService';
+import { findByAlias, findByName, addAlias, createContact } from '../lib/contactService';
 import { classifyIntent, suggestAction } from '../lib/llmService';
 import { transcribeAudio } from '../lib/whisperService';
 import multer from 'multer';
@@ -269,12 +269,18 @@ async function handleIncomingWhatsApp(
       }
 
       case 'SEND_TO': {
-        const contacts = parseContacts(process.env.WHATSAPP_CONTACTS ?? '');
-        const contact = contacts.find(
+        // 1. DB contacts (via contactService)
+        const dbContact = await findByName(args?.contactName ?? '');
+        // 2. Fallback: WHATSAPP_CONTACTS env var
+        const envContacts = parseContacts(process.env.WHATSAPP_CONTACTS ?? '');
+        const envContact = envContacts.find(
           (c) => c.name.toLowerCase() === (args?.contactName ?? '').toLowerCase()
         );
+        const contact = dbContact
+          ? { name: dbContact.name, phone: dbContact.phone }
+          : envContact ?? null;
         if (!contact) {
-          responseText = `❌ "${args?.contactName}" não encontrado. Adicione em WHATSAPP_CONTACTS=nome:numero`;
+          responseText = `❌ "${args?.contactName}" não encontrado. Cadastre com /criar-contato ou adicione em WHATSAPP_CONTACTS=nome:numero`;
           break;
         }
         const comm = await prisma.communication.create({


### PR DESCRIPTION
## Summary

- `SEND_TO` agora busca o contato via `findByName()` no banco de dados primeiro
- `WHATSAPP_CONTACTS` env var continua como fallback
- Resolve o problema onde contatos cadastrados via DB não eram encontrados no fluxo de áudio

## Test plan

- [ ] 192 testes passando
- [ ] Mandar áudio "Manda um oi pra Amanda" com Amanda cadastrada no DB → preview SEND_TO correto

🤖 Generated with [Claude Code](https://claude.com/claude-code)