### PR TITLE
feat(audio): normalizar linguagem natural com LLM antes do pipeline

### DIFF
--- a/apps/api/src/lib/__tests__/llmService.test.ts
+++ b/apps/api/src/lib/__tests__/llmService.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
-import { classifyIntent, type LLMClassification } from '../llmService';
+import { classifyIntent, normalizeAudioCommand, type LLMClassification } from '../llmService';
 
 function groqResponse(content: string) {
   return {
@@ -62,5 +62,38 @@ describe('classifyIntent', () => {
     mockFetch.mockRejectedValue(new Error('network error'));
     const result = await classifyIntent('qualquer coisa');
     expect(result).toEqual<LLMClassification>({ intent: 'UNKNOWN' });
+  });
+});
+
+describe('normalizeAudioCommand', () => {
+  it('normaliza comando de envio: "Manda um oi pra Amanda" → "manda para Amanda: oi"', async () => {
+    mockFetch.mockResolvedValue(
+      groqResponse('manda para Amanda: oi')
+    );
+
+    const result = await normalizeAudioCommand('Manda um oi pra Amanda.');
+    expect(result).toBe('manda para Amanda: oi');
+  });
+
+  it('retorna texto limpo para comandos sem envio: "lembra de comprar pão"', async () => {
+    mockFetch.mockResolvedValue(
+      groqResponse('comprar pão')
+    );
+
+    const result = await normalizeAudioCommand('lembra de comprar pão amanhã');
+    expect(result).toBe('comprar pão');
+  });
+
+  it('retorna o texto original quando API key está ausente', async () => {
+    delete process.env.GROQ_API_KEY;
+    const result = await normalizeAudioCommand('Manda um oi pra Amanda.');
+    expect(result).toBe('Manda um oi pra Amanda.');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('retorna o texto original quando LLM falha', async () => {
+    mockFetch.mockRejectedValue(new Error('network error'));
+    const result = await normalizeAudioCommand('Manda um oi pra Amanda.');
+    expect(result).toBe('Manda um oi pra Amanda.');
   });
 });

--- a/apps/api/src/lib/llmService.ts
+++ b/apps/api/src/lib/llmService.ts
@@ -60,6 +60,50 @@ export async function suggestAction(text: string): Promise<SuggestedAction> {
   }
 }
 
+const PROMPT_NORMALIZE_SYSTEM = `Você converte transcrições de áudio em comandos estruturados para o assistente Elvis.
+
+Regras:
+- Se o usuário quer mandar mensagem para alguém: responda APENAS com "manda para <nome>: <mensagem limpa>"
+  - Remova palavras de preenchimento: "um", "uma", "só", "lá", "aí", "né"
+  - Exemplos:
+    - "Manda um oi pra Amanda" → "manda para Amanda: oi"
+    - "Fala pra João que eu chego às 18h" → "manda para João: chego às 18h"
+    - "Manda uma mensagem pra Linic dizendo obrigado" → "manda para Linic: obrigado"
+- Para qualquer outro tipo de comando (criar tarefa, lembrete, etc.): responda APENAS com o texto limpo e objetivo, sem verbos de instrução como "lembra de", "precisa de", etc.
+  - "Lembra de comprar pão amanhã" → "comprar pão amanhã"
+  - "Preciso ligar pra dentista" → "ligar pra dentista"
+- Responda APENAS com o comando normalizado. Nenhum texto adicional.`;
+
+export async function normalizeAudioCommand(text: string): Promise<string> {
+  const apiKey = process.env.GROQ_API_KEY;
+  if (!apiKey) return text;
+
+  try {
+    const res = await fetch(GROQ_API_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'llama-3.3-70b-versatile',
+        messages: [
+          { role: 'system', content: PROMPT_NORMALIZE_SYSTEM },
+          { role: 'user', content: text },
+        ],
+        temperature: 0,
+        max_tokens: 100,
+      }),
+    });
+
+    const data = await res.json() as { choices?: Array<{ message?: { content?: string } }> };
+    const normalized = (data?.choices?.[0]?.message?.content ?? '').trim();
+    return normalized || text;
+  } catch {
+    return text;
+  }
+}
+
 export async function classifyIntent(text: string): Promise<LLMClassification> {
   const apiKey = process.env.GROQ_API_KEY;
   if (!apiKey) return { intent: 'UNKNOWN' };

--- a/apps/api/src/routes/__tests__/webhook.audio.test.ts
+++ b/apps/api/src/routes/__tests__/webhook.audio.test.ts
@@ -20,6 +20,7 @@ vi.mock('../../lib/whisperService', () => ({
 vi.mock('../../lib/llmService', () => ({
   classifyIntent: vi.fn(),
   suggestAction: vi.fn(),
+  normalizeAudioCommand: vi.fn((text: string) => Promise.resolve(text)),
 }));
 
 vi.mock('../../lib/redis', () => ({

--- a/apps/api/src/routes/webhook.ts
+++ b/apps/api/src/routes/webhook.ts
@@ -8,7 +8,7 @@ import { utcToZonedTime } from 'date-fns-tz';
 import { getEmailSummary } from '../lib/emailService';
 import { getOrCreateProfile } from '../lib/userModel';
 import { findByAlias, findByName, addAlias, createContact } from '../lib/contactService';
-import { classifyIntent, suggestAction } from '../lib/llmService';
+import { classifyIntent, suggestAction, normalizeAudioCommand } from '../lib/llmService';
 import { transcribeAudio } from '../lib/whisperService';
 import multer from 'multer';
 import redis from '../lib/redis';
@@ -442,8 +442,9 @@ router.post('/webhook/baileys-audio', upload.single('audio'), async (req, res) =
         await sendWhatsApp(sender_id, responseText);
       }
     } else {
-      // Route through the full command pipeline — SEND_TO/ALIAS/task have their own confirm steps
-      const result = await handleIncomingWhatsApp(sender_id, text);
+      // Normalize natural language before routing through the full command pipeline
+      const normalized = await normalizeAudioCommand(text);
+      const result = await handleIncomingWhatsApp(sender_id, normalized);
       await sendWhatsApp(sender_id, `🎙️ Entendi: "${text}"\n\n${result}`);
     }
 


### PR DESCRIPTION
## Problema

O áudio "Manda um oi pra Amanda" gerava o draft com mensagem "um oi" em vez de "oi" — o regex captura literalmente o que está entre "manda" e "pra".

## Solução

Nova função `normalizeAudioCommand()` no `llmService` que usa `llama-3.3-70b-versatile` para converter a transcrição em um comando estruturado antes de entrar no pipeline:

- `"Manda um oi pra Amanda."` → `"manda para Amanda: oi"`
- `"Lembra de comprar pão amanhã"` → `"comprar pão amanhã"`
- Fallback para o texto original em caso de falha ou sem `GROQ_API_KEY`

## Test plan

- [ ] 196 testes passando
- [ ] Mandar áudio "Manda um oi pra Amanda" → preview deve mostrar mensagem "oi", não "um oi"

🤖 Generated with [Claude Code](https://claude.com/claude-code)