### PR TITLE
feat(contacts): owner_alias por contato

### DIFF
--- a/apps/api/src/lib/__tests__/contactService.test.ts
+++ b/apps/api/src/lib/__tests__/contactService.test.ts
@@ -18,6 +18,7 @@ import {
   findByName,
   addAlias,
   createContact,
+  setOwnerAlias,
   listContacts,
 } from '../contactService';
 
@@ -26,6 +27,7 @@ const linic = {
   name: 'Linic',
   phone: '5511988880000',
   aliases: ['/linic', 'linic'],
+  owner_alias: 'Rafael',
   created_at: new Date(),
 };
 
@@ -86,13 +88,44 @@ describe('addAlias', () => {
 });
 
 describe('createContact', () => {
-  it('creates a new contact with aliases', async () => {
+  it('uses OWNER_NAME env var as owner_alias when not provided', async () => {
+    process.env.OWNER_NAME = 'Rafael';
     (prisma.contact.create as any).mockResolvedValue(linic);
     const result = await createContact('Linic', '5511988880000', ['/linic']);
     expect(prisma.contact.create).toHaveBeenCalledWith({
-      data: { name: 'Linic', phone: '5511988880000', aliases: ['/linic'] },
+      data: { name: 'Linic', phone: '5511988880000', aliases: ['/linic'], owner_alias: 'Rafael' },
     });
     expect(result).toEqual(linic);
+  });
+
+  it('uses explicit ownerAlias when provided', async () => {
+    (prisma.contact.create as any).mockResolvedValue({ ...linic, owner_alias: 'Rafa' });
+    const result = await createContact('Linic', '5511988880000', ['/linic'], 'Rafa');
+    expect(prisma.contact.create).toHaveBeenCalledWith({
+      data: { name: 'Linic', phone: '5511988880000', aliases: ['/linic'], owner_alias: 'Rafa' },
+    });
+    expect(result.owner_alias).toBe('Rafa');
+  });
+});
+
+describe('setOwnerAlias', () => {
+  it('updates owner_alias for existing contact', async () => {
+    (prisma.contact.findFirst as any).mockResolvedValue(linic);
+    const updated = { ...linic, owner_alias: 'pai' };
+    (prisma.contact.update as any).mockResolvedValue(updated);
+
+    const result = await setOwnerAlias('Linic', 'pai');
+
+    expect(prisma.contact.update).toHaveBeenCalledWith({
+      where: { id: linic.id },
+      data: { owner_alias: 'pai' },
+    });
+    expect(result.owner_alias).toBe('pai');
+  });
+
+  it('throws if contact not found', async () => {
+    (prisma.contact.findFirst as any).mockResolvedValue(null);
+    await expect(setOwnerAlias('Desconhecido', 'pai')).rejects.toThrow('not found');
   });
 });
 

--- a/apps/api/src/lib/__tests__/llmService.test.ts
+++ b/apps/api/src/lib/__tests__/llmService.test.ts
@@ -78,10 +78,10 @@ describe('normalizeAudioCommand', () => {
     expect(result).toBe('manda para Estela: seu RG está na casa da Karen');
   });
 
-  it('inclui atribuição quando dono pede para "falar que eu disse"', async () => {
-    mockFetch.mockResolvedValue(groqResponse('manda para Estela: seu pai pediu pra avisar: seu RG está na casa da Karen'));
+  it('inclui atribuição neutra quando dono pede para "falar que eu disse"', async () => {
+    mockFetch.mockResolvedValue(groqResponse('manda para Estela: ele pediu pra te avisar: seu RG está na casa da Karen'));
     const result = await normalizeAudioCommand('Fala pra Estela que eu pedi pra avisar que o RG dela tá na casa da Karen');
-    expect(result).toBe('manda para Estela: seu pai pediu pra avisar: seu RG está na casa da Karen');
+    expect(result).toBe('manda para Estela: ele pediu pra te avisar: seu RG está na casa da Karen');
   });
 
   it('retorna texto limpo para comandos sem envio: "lembra de comprar pão"', async () => {

--- a/apps/api/src/lib/__tests__/llmService.test.ts
+++ b/apps/api/src/lib/__tests__/llmService.test.ts
@@ -63,6 +63,43 @@ describe('classifyIntent', () => {
     const result = await classifyIntent('qualquer coisa');
     expect(result).toEqual<LLMClassification>({ intent: 'UNKNOWN' });
   });
+
+  it('returns CREATE_CONTACT with phone', async () => {
+    mockFetch.mockResolvedValue(
+      groqResponse('{"intent":"CREATE_CONTACT","contact_name":"Carlinha","phone":"5511999990000"}')
+    );
+    const result = await classifyIntent('cria o contato Carlinha, número 5511999990000');
+    expect(result).toEqual<LLMClassification>({
+      intent: 'CREATE_CONTACT',
+      contact_name: 'Carlinha',
+      phone: '5511999990000',
+    });
+  });
+
+  it('returns CREATE_CONTACT with optional owner_alias', async () => {
+    mockFetch.mockResolvedValue(
+      groqResponse('{"intent":"CREATE_CONTACT","contact_name":"Carlinha","phone":"5511999990000","owner_alias":"Rafa"}')
+    );
+    const result = await classifyIntent('cria o contato Carlinha, número 5511999990000, interação Rafa');
+    expect(result).toEqual<LLMClassification>({
+      intent: 'CREATE_CONTACT',
+      contact_name: 'Carlinha',
+      phone: '5511999990000',
+      owner_alias: 'Rafa',
+    });
+  });
+
+  it('returns SET_OWNER_ALIAS', async () => {
+    mockFetch.mockResolvedValue(
+      groqResponse('{"intent":"SET_OWNER_ALIAS","contact_name":"Estela","owner_alias":"pai"}')
+    );
+    const result = await classifyIntent('agora sou o pai pra Estela');
+    expect(result).toEqual<LLMClassification>({
+      intent: 'SET_OWNER_ALIAS',
+      contact_name: 'Estela',
+      owner_alias: 'pai',
+    });
+  });
 });
 
 describe('normalizeAudioCommand', () => {
@@ -102,5 +139,14 @@ describe('normalizeAudioCommand', () => {
     mockFetch.mockRejectedValue(new Error('network error'));
     const result = await normalizeAudioCommand('Manda um oi pra Amanda.');
     expect(result).toBe('Manda um oi pra Amanda.');
+  });
+
+  it('usa ownerAlias do contato quando fornecido', async () => {
+    mockFetch.mockResolvedValue(groqResponse('manda para Linic: Rafa chega às 18h'));
+    const result = await normalizeAudioCommand('Fala pra Linic que eu chego às 18h', 'Rafa');
+    expect(result).toBe('manda para Linic: Rafa chega às 18h');
+    // verifica que o prompt enviado contém "Rafa"
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.messages[0].content).toContain('Rafa');
   });
 });

--- a/apps/api/src/lib/__tests__/llmService.test.ts
+++ b/apps/api/src/lib/__tests__/llmService.test.ts
@@ -78,10 +78,11 @@ describe('normalizeAudioCommand', () => {
     expect(result).toBe('manda para Estela: seu RG está na casa da Karen');
   });
 
-  it('inclui atribuição neutra quando dono pede para "falar que eu disse"', async () => {
-    mockFetch.mockResolvedValue(groqResponse('manda para Estela: ele pediu pra te avisar: seu RG está na casa da Karen'));
+  it('inclui nome do dono (OWNER_NAME) quando pede para "falar que eu disse"', async () => {
+    process.env.OWNER_NAME = 'Rafael';
+    mockFetch.mockResolvedValue(groqResponse('manda para Estela: Rafael pediu pra te avisar: seu RG está na casa da Karen'));
     const result = await normalizeAudioCommand('Fala pra Estela que eu pedi pra avisar que o RG dela tá na casa da Karen');
-    expect(result).toBe('manda para Estela: ele pediu pra te avisar: seu RG está na casa da Karen');
+    expect(result).toBe('manda para Estela: Rafael pediu pra te avisar: seu RG está na casa da Karen');
   });
 
   it('retorna texto limpo para comandos sem envio: "lembra de comprar pão"', async () => {

--- a/apps/api/src/lib/contactService.ts
+++ b/apps/api/src/lib/contactService.ts
@@ -23,9 +23,18 @@ export async function addAlias(contactName: string, alias: string): Promise<Cont
 export async function createContact(
   name: string,
   phone: string,
-  aliases: string[]
+  aliases: string[],
+  ownerAlias?: string,
 ): Promise<Contact> {
-  return prisma.contact.create({ data: { name, phone, aliases } });
+  return prisma.contact.create({
+    data: { name, phone, aliases, owner_alias: ownerAlias ?? process.env.OWNER_NAME ?? 'Rafael' },
+  });
+}
+
+export async function setOwnerAlias(contactName: string, alias: string): Promise<Contact> {
+  const contact = await findByName(contactName);
+  if (!contact) throw new Error(`Contact "${contactName}" not found`);
+  return prisma.contact.update({ where: { id: contact.id }, data: { owner_alias: alias } });
 }
 
 export async function listContacts(): Promise<Contact[]> {

--- a/apps/api/src/lib/llmService.ts
+++ b/apps/api/src/lib/llmService.ts
@@ -66,13 +66,13 @@ Se o dono quer mandar mensagem para alguém: responda APENAS com "manda para <no
   IMPORTANTE — reformule a mensagem na perspectiva de quem vai receber:
   - Troque "eu" → "seu pai" / "ele" conforme o contexto
   - Troque "dela" / "seu" → "seu" / "teu" dirigindo-se ao destinatário
-  - Se o dono pedir para "avisar que eu disse" ou "falar que fui eu": inclua "Seu pai pediu pra avisar:" no início
+  - Se o dono pedir para "avisar que eu disse" ou "falar que fui eu": inclua "Ele pediu pra te avisar:" no início
   - A mensagem final deve fazer sentido para quem a recebe, como se fosse enviada diretamente
   Exemplos:
     "Manda um oi pra Amanda" → "manda para Amanda: oi"
     "Diga para Estela que o RG dela está na casa da Karen" → "manda para Estela: seu RG está na casa da Karen"
-    "Fala pra Estela que eu pedi pra avisar que o RG dela tá na casa da Karen" → "manda para Estela: seu pai pediu pra avisar: seu RG está na casa da Karen"
-    "Fala pra João que eu chego às 18h" → "manda para João: seu pai chega às 18h"
+    "Fala pra Estela que eu pedi pra avisar que o RG dela tá na casa da Karen" → "manda para Estela: ele pediu pra te avisar: seu RG está na casa da Karen"
+    "Fala pra João que eu chego às 18h" → "manda para João: ele chega às 18h"
 
 Para qualquer outro tipo de comando (tarefa, lembrete, etc.): responda APENAS com o texto limpo e objetivo.
   "Lembra de comprar pão amanhã" → "comprar pão amanhã"

--- a/apps/api/src/lib/llmService.ts
+++ b/apps/api/src/lib/llmService.ts
@@ -60,28 +60,32 @@ export async function suggestAction(text: string): Promise<SuggestedAction> {
   }
 }
 
-const PROMPT_NORMALIZE_SYSTEM = `Você é o assistente Elvis. Converte transcrições de áudio do dono em comandos estruturados.
+function buildNormalizePrompt(ownerName: string): string {
+  return `Você é o assistente Elvis. Converte transcrições de áudio do dono (${ownerName}) em comandos estruturados.
 
 Se o dono quer mandar mensagem para alguém: responda APENAS com "manda para <nome>: <mensagem>"
   IMPORTANTE — reformule a mensagem na perspectiva de quem vai receber:
-  - Troque "eu" → "seu pai" / "ele" conforme o contexto
-  - Troque "dela" / "seu" → "seu" / "teu" dirigindo-se ao destinatário
-  - Se o dono pedir para "avisar que eu disse" ou "falar que fui eu": inclua "Ele pediu pra te avisar:" no início
+  - Troque pronomes de primeira pessoa pelo nome do dono (${ownerName})
+  - Troque "dela" / "seu" para o destinatário conforme o contexto
+  - Se o dono pedir para "avisar que eu disse" ou "falar que fui eu": inclua "${ownerName} pediu pra te avisar:" no início
   - A mensagem final deve fazer sentido para quem a recebe, como se fosse enviada diretamente
-  Exemplos:
+  Exemplos (dono = ${ownerName}):
     "Manda um oi pra Amanda" → "manda para Amanda: oi"
     "Diga para Estela que o RG dela está na casa da Karen" → "manda para Estela: seu RG está na casa da Karen"
-    "Fala pra Estela que eu pedi pra avisar que o RG dela tá na casa da Karen" → "manda para Estela: ele pediu pra te avisar: seu RG está na casa da Karen"
-    "Fala pra João que eu chego às 18h" → "manda para João: ele chega às 18h"
+    "Fala pra Estela que eu pedi pra avisar que o RG dela tá na casa da Karen" → "manda para Estela: ${ownerName} pediu pra te avisar: seu RG está na casa da Karen"
+    "Fala pra João que eu chego às 18h" → "manda para João: ${ownerName} chega às 18h"
 
 Para qualquer outro tipo de comando (tarefa, lembrete, etc.): responda APENAS com o texto limpo e objetivo.
   "Lembra de comprar pão amanhã" → "comprar pão amanhã"
 
 Responda APENAS com o comando normalizado. Nenhum texto adicional.`;
+}
 
 export async function normalizeAudioCommand(text: string): Promise<string> {
   const apiKey = process.env.GROQ_API_KEY;
   if (!apiKey) return text;
+
+  const ownerName = process.env.OWNER_NAME ?? 'o dono';
 
   try {
     const res = await fetch(GROQ_API_URL, {
@@ -93,7 +97,7 @@ export async function normalizeAudioCommand(text: string): Promise<string> {
       body: JSON.stringify({
         model: 'llama-3.3-70b-versatile',
         messages: [
-          { role: 'system', content: PROMPT_NORMALIZE_SYSTEM },
+          { role: 'system', content: buildNormalizePrompt(ownerName) },
           { role: 'user', content: text },
         ],
         temperature: 0,

--- a/apps/api/src/lib/llmService.ts
+++ b/apps/api/src/lib/llmService.ts
@@ -1,17 +1,24 @@
 export type LLMClassification =
   | { intent: 'REGISTER_ALIAS'; alias: string; contact_name: string }
-  | { intent: 'CREATE_CONTACT'; contact_name: string; phone: string }
+  | { intent: 'CREATE_CONTACT'; contact_name: string; phone: string; owner_alias?: string }
+  | { intent: 'SET_OWNER_ALIAS'; contact_name: string; owner_alias: string }
   | { intent: 'UNKNOWN' };
 
 const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
 const PROMPT_SYSTEM = `Você é um classificador de intenções para um assistente pessoal chamado Elvis.
 Analise a mensagem e retorne JSON com UMA destas estruturas:
 
-- Criação de NOVO contato com número de telefone: {"intent":"CREATE_CONTACT","contact_name":"<nome>","phone":"<somente dígitos, ex: 5511999990000>"}
+- Criação de NOVO contato com número de telefone: {"intent":"CREATE_CONTACT","contact_name":"<nome>","phone":"<somente dígitos, ex: 5511999990000>","owner_alias":"<opcional: como o dono quer ser chamado por este contato>"}
   Use quando a mensagem contiver um número de telefone E o usuário quiser cadastrar/criar/adicionar um contato.
+  Se a mensagem mencionar interação, apelido ou como o dono quer ser chamado, inclua em owner_alias.
+  Ex: "cria o contato Carlinha, número 5511999, interação Rafa" → owner_alias="Rafa"
 
 - Registro de atalho para contato JÁ EXISTENTE (sem número, com atalho tipo /nome): {"intent":"REGISTER_ALIAS","alias":"<atalho>","contact_name":"<nome>"}
   Use APENAS quando houver um atalho explícito (começa com /) e NÃO houver número de telefone.
+
+- Alteração de como o dono se identifica com um contato: {"intent":"SET_OWNER_ALIAS","contact_name":"<nome>","owner_alias":"<como o dono quer ser chamado>"}
+  Use quando pedirem para mudar/alterar/definir como o dono aparece ou se chama para um contato específico.
+  Ex: "agora sou o pai pra Estela", "muda meu nome pra Linic para Rafa", "altere a interação com a Amanda para Amor"
 
 - Qualquer outra coisa: {"intent":"UNKNOWN"}
 
@@ -81,11 +88,11 @@ Para qualquer outro tipo de comando (tarefa, lembrete, etc.): responda APENAS co
 Responda APENAS com o comando normalizado. Nenhum texto adicional.`;
 }
 
-export async function normalizeAudioCommand(text: string): Promise<string> {
+export async function normalizeAudioCommand(text: string, ownerAlias?: string): Promise<string> {
   const apiKey = process.env.GROQ_API_KEY;
   if (!apiKey) return text;
 
-  const ownerName = process.env.OWNER_NAME ?? 'o dono';
+  const ownerName = ownerAlias ?? process.env.OWNER_NAME ?? 'o dono';
 
   try {
     const res = await fetch(GROQ_API_URL, {
@@ -143,7 +150,15 @@ export async function classifyIntent(text: string): Promise<LLMClassification> {
       return { intent: 'REGISTER_ALIAS', alias: parsed.alias, contact_name: parsed.contact_name };
     }
     if (parsed.intent === 'CREATE_CONTACT' && parsed.contact_name && parsed.phone) {
-      return { intent: 'CREATE_CONTACT', contact_name: parsed.contact_name, phone: String(parsed.phone) };
+      return {
+        intent: 'CREATE_CONTACT',
+        contact_name: parsed.contact_name,
+        phone: String(parsed.phone),
+        ...(parsed.owner_alias ? { owner_alias: String(parsed.owner_alias) } : {}),
+      };
+    }
+    if (parsed.intent === 'SET_OWNER_ALIAS' && parsed.contact_name && parsed.owner_alias) {
+      return { intent: 'SET_OWNER_ALIAS', contact_name: parsed.contact_name, owner_alias: String(parsed.owner_alias) };
     }
     return { intent: 'UNKNOWN' };
   } catch {

--- a/apps/api/src/routes/webhook.ts
+++ b/apps/api/src/routes/webhook.ts
@@ -7,7 +7,7 @@ import { addDays, nextMonday } from 'date-fns';
 import { utcToZonedTime } from 'date-fns-tz';
 import { getEmailSummary } from '../lib/emailService';
 import { getOrCreateProfile } from '../lib/userModel';
-import { findByAlias, findByName, addAlias, createContact } from '../lib/contactService';
+import { findByAlias, findByName, addAlias, createContact, setOwnerAlias } from '../lib/contactService';
 import { classifyIntent, suggestAction, normalizeAudioCommand } from '../lib/llmService';
 import { transcribeAudio } from '../lib/whisperService';
 import multer from 'multer';
@@ -223,10 +223,20 @@ async function handleIncomingWhatsApp(
         if (classification.intent === 'CREATE_CONTACT') {
           const alias = '/' + classification.contact_name.toLowerCase().replace(/\s+/g, '');
           try {
-            await createContact(classification.contact_name, classification.phone, [alias]);
+            await createContact(classification.contact_name, classification.phone, [alias], classification.owner_alias);
             responseText = `✅ Contato *${classification.contact_name}* criado! Use ${alias} <msg> para mandar mensagem.`;
           } catch {
             responseText = `❌ Não consegui criar o contato. Verifique se o nome já existe.`;
+          }
+          break;
+        }
+
+        if (classification.intent === 'SET_OWNER_ALIAS') {
+          try {
+            await setOwnerAlias(classification.contact_name, classification.owner_alias);
+            responseText = `✅ Pronto! Agora nas mensagens para *${classification.contact_name}* você é *${classification.owner_alias}*.`;
+          } catch {
+            responseText = `❌ Contato "${classification.contact_name}" não encontrado.`;
           }
           break;
         }
@@ -442,9 +452,22 @@ router.post('/webhook/baileys-audio', upload.single('audio'), async (req, res) =
         await sendWhatsApp(sender_id, responseText);
       }
     } else {
-      // Normalize natural language before routing through the full command pipeline
+      // Passo 1: normalizar com OWNER_NAME global para detectar o contato
       const normalized = await normalizeAudioCommand(text);
-      const result = await handleIncomingWhatsApp(sender_id, normalized);
+      let finalNormalized = normalized;
+
+      // Passo 2: se for SEND_TO, buscar owner_alias específico do contato
+      const parsed = parseCommand(normalized);
+      if (parsed.intent === 'SEND_TO' && parsed.args?.contactName) {
+        const contact = await findByName(parsed.args.contactName);
+        const contactAlias = contact?.owner_alias;
+        const defaultAlias = process.env.OWNER_NAME ?? 'Rafael';
+        if (contactAlias && contactAlias !== defaultAlias) {
+          finalNormalized = await normalizeAudioCommand(text, contactAlias);
+        }
+      }
+
+      const result = await handleIncomingWhatsApp(sender_id, finalNormalized);
       await sendWhatsApp(sender_id, `🎙️ Entendi: "${text}"\n\n${result}`);
     }
 

--- a/prisma/migrations/20260411132253_add_owner_alias_to_contact/migration.sql
+++ b/prisma/migrations/20260411132253_add_owner_alias_to_contact/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Contact" ADD COLUMN     "owner_alias" TEXT NOT NULL DEFAULT 'Rafael';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -130,11 +130,12 @@ model OAuthToken {
 }
 
 model Contact {
-  id         String   @id @default(uuid())
-  name       String   @unique
-  phone      String
-  aliases    String[]
-  created_at DateTime @default(now())
+  id          String   @id @default(uuid())
+  name        String   @unique
+  phone       String
+  aliases     String[]
+  owner_alias String   @default("Rafael")
+  created_at  DateTime @default(now())
 
   @@index([aliases])
 }


### PR DESCRIPTION
## Summary

- Novo campo `owner_alias` no modelo Contact (migration SQL incluída) — armazena como o dono se identifica para cada contato (ex: "pai" para Estela, "Rafa" para Linic)
- `createContact` aceita `ownerAlias` opcional; default silencioso = `OWNER_NAME` env var
- Nova função `setOwnerAlias` para alterar alias de contato existente via texto ou áudio
- LLM classifica `SET_OWNER_ALIAS` e `CREATE_CONTACT` com `owner_alias` opcional em um único comando
- `normalizeAudioCommand(text, ownerAlias?)` usa nome correto por contato ao reformular mensagens
- Webhook: case `SET_OWNER_ALIAS`, `CREATE_CONTACT` passa alias, fluxo de áudio em dois passos

## Test plan

- [x] 205 testes passando (7 novos)
- [ ] Criar contato com alias: "cria o contato Carlinha, número 123, interação Rafa" → `owner_alias = "Rafa"` no banco
- [ ] Criar sem alias: "cria o contato Pedro, número 456" → `owner_alias = OWNER_NAME` silenciosamente
- [ ] Alterar alias: "agora sou o pai pra Estela" → banco atualizado, confirmação no WhatsApp
- [ ] Áudio SEND_TO: "Fala pra Linic que eu chego às 18h" → preview "Rafa chega às 18h"
- [ ] Migração no servidor: `docker compose exec api npx prisma migrate deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)