### PR TITLE
fix(audio): naturalizar prompt com coloquial brasileiro

### DIFF
--- a/apps/api/src/lib/__tests__/llmService.test.ts
+++ b/apps/api/src/lib/__tests__/llmService.test.ts
@@ -115,11 +115,32 @@ describe('normalizeAudioCommand', () => {
     expect(result).toBe('manda para Estela: seu RG está na casa da Karen');
   });
 
-  it('inclui nome do dono (OWNER_NAME) quando pede para "falar que eu disse"', async () => {
+  it('usa "mandou dizer" ao repassar informação com nome próprio (sem redundância)', async () => {
     process.env.OWNER_NAME = 'Rafael';
-    mockFetch.mockResolvedValue(groqResponse('manda para Estela: Rafael pediu pra te avisar: seu RG está na casa da Karen'));
+    mockFetch.mockResolvedValue(groqResponse('manda para Estela: Rafael mandou dizer que seu RG está na casa da Karen'));
     const result = await normalizeAudioCommand('Fala pra Estela que eu pedi pra avisar que o RG dela tá na casa da Karen');
-    expect(result).toBe('manda para Estela: Rafael pediu pra te avisar: seu RG está na casa da Karen');
+    expect(result).toBe('manda para Estela: Rafael mandou dizer que seu RG está na casa da Karen');
+  });
+
+  it('usa "teu pai pediu pra você" ao repassar pedido com título de parentesco', async () => {
+    mockFetch.mockResolvedValue(groqResponse('manda para Estela: teu pai pediu pra você voltar a colocar as vogais nas palavras'));
+    const result = await normalizeAudioCommand(
+      'diga para a Estela que eu pedi para ela voltar a colocar as vogais nas palavras',
+      'pai'
+    );
+    expect(result).toBe('manda para Estela: teu pai pediu pra você voltar a colocar as vogais nas palavras');
+    // verifica que o prompt usa "teu pai" e não só "pai"
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.messages[0].content).toContain('teu pai');
+  });
+
+  it('usa "teu pai mandou dizer" ao repassar informação com título de parentesco', async () => {
+    mockFetch.mockResolvedValue(groqResponse('manda para Estela: teu pai mandou dizer que seu RG está na casa da Karen'));
+    const result = await normalizeAudioCommand(
+      'fala pra Estela que o RG dela tá na casa da Karen',
+      'pai'
+    );
+    expect(result).toBe('manda para Estela: teu pai mandou dizer que seu RG está na casa da Karen');
   });
 
   it('retorna texto limpo para comandos sem envio: "lembra de comprar pão"', async () => {

--- a/apps/api/src/lib/llmService.ts
+++ b/apps/api/src/lib/llmService.ts
@@ -68,19 +68,28 @@ export async function suggestAction(text: string): Promise<SuggestedAction> {
 }
 
 function buildNormalizePrompt(ownerName: string): string {
+  // Se ownerName for título de parentesco, usar com possessivo (ex: "teu pai")
+  const KINSHIP = ['pai', 'mãe', 'mae', 'tio', 'tia', 'avô', 'avo', 'avó', 'irmão', 'irmao', 'irmã', 'irma'];
+  const isKinship = KINSHIP.includes(ownerName.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, ''));
+  const ownerRef = isKinship ? `teu ${ownerName}` : ownerName;
+
   return `Você é o assistente Elvis. Converte transcrições de áudio do dono (${ownerName}) em comandos estruturados.
 
 Se o dono quer mandar mensagem para alguém: responda APENAS com "manda para <nome>: <mensagem>"
   IMPORTANTE — reformule a mensagem na perspectiva de quem vai receber:
-  - Troque pronomes de primeira pessoa pelo nome do dono (${ownerName})
+  - Troque pronomes de primeira pessoa pela referência correta ao dono: "${ownerRef}"
   - Troque "dela" / "seu" para o destinatário conforme o contexto
-  - Se o dono pedir para "avisar que eu disse" ou "falar que fui eu": inclua "${ownerName} pediu pra te avisar:" no início
-  - A mensagem final deve fazer sentido para quem a recebe, como se fosse enviada diretamente
-  Exemplos (dono = ${ownerName}):
+  - Se o dono pedir para alguém FAZER algo: use "${ownerRef} pediu pra você [ação no infinitivo]"
+  - Se o dono quiser repassar uma INFORMAÇÃO em seu nome: use "${ownerRef} mandou dizer que [fato]"
+  - Se o dono fala algo sobre si mesmo (chega, vai, está): use "${ownerRef} [ação]"
+  - NÃO use dois pontos após "pediu" ou "mandou dizer". NÃO repita "ele pediu" ou "eu pedi" no conteúdo.
+  - A mensagem final deve soar natural, como se fosse enviada diretamente pelo assistente
+  Exemplos (dono = ${ownerName}, referência = ${ownerRef}):
     "Manda um oi pra Amanda" → "manda para Amanda: oi"
     "Diga para Estela que o RG dela está na casa da Karen" → "manda para Estela: seu RG está na casa da Karen"
-    "Fala pra Estela que eu pedi pra avisar que o RG dela tá na casa da Karen" → "manda para Estela: ${ownerName} pediu pra te avisar: seu RG está na casa da Karen"
-    "Fala pra João que eu chego às 18h" → "manda para João: ${ownerName} chega às 18h"
+    "Fala pra Estela que eu pedi pra avisar que o RG dela tá na casa da Karen" → "manda para Estela: ${ownerRef} mandou dizer que seu RG está na casa da Karen"
+    "Fala pra Estela que eu pedi para ela voltar a colocar as vogais nas palavras" → "manda para Estela: ${ownerRef} pediu pra você voltar a colocar as vogais nas palavras"
+    "Fala pra João que eu chego às 18h" → "manda para João: ${ownerRef} chega às 18h"
 
 Para qualquer outro tipo de comando (tarefa, lembrete, etc.): responda APENAS com o texto limpo e objetivo.
   "Lembra de comprar pão amanhã" → "comprar pão amanhã"


### PR DESCRIPTION
## Problema

O Elvis produzia frases redundantes ao repassar pedidos:
> ❌ "seu pai pediu pra avisar: **ele pediu para você** voltar a colocar as vogais"

## Causa raiz

O prompt usava `ownerName` diretamente ("pai pediu pra você"), mas em português coloquial:
- Títulos de parentesco precisam do possessivo ao falar com terceiros: **"teu pai"**, não "pai"
- O separador `:` após "pediu pra te avisar" fazia o LLM repetir o verbo no conteúdo

## Solução

- Detectar automaticamente se `ownerName` é título de parentesco (pai, mãe, tio...) → usar `"teu ${ownerName}"`
- Distinguir pedido vs. informação:
  - Pedido (ação): `"teu pai pediu pra você [verbo]"`
  - Informação: `"teu pai mandou dizer que [fato]"`
- Exemplos concretos com os dois padrões no prompt

## Resultado

> ✅ "teu pai pediu pra você voltar a colocar as vogais nas palavras"

## Test plan

- [x] 207 testes passando (3 novos)
- [ ] Testar no WhatsApp: "Elvis, diga para a Estela que eu pedi para ela [X]" → "teu pai pediu pra você [X]"
- [ ] Testar repasse de informação: "fala pra Linic que o RG dela tá na Karen" → "Rafa mandou dizer que seu RG está na casa da Karen"

🤖 Generated with [Claude Code](https://claude.com/claude-code)