### PR TITLE
fix: CORS restritivo + atomicidade Communication+AuditLog

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -40,6 +40,11 @@ GOOGLE_CLIENT_SECRET=your_google_client_secret
 KNOWN_CONTACT_DOMAINS=mckinsey.com,gmail.com
 IMPORTANT_KEYWORDS=urgente,ação necessária,prazo,aprovação
 
+# ── CORS ─────────────────────────────────────────────────────────────────────
+# Deixe vazio para desabilitar CORS (padrão — API só recebe chamadas server-to-server).
+# Preencha com a origem do admin web quando ele existir: https://admin.yourdomain.com
+CORS_ORIGIN=
+
 # ── Caddy / domain ───────────────────────────────────────────────────────────
 ELVIS_DOMAIN=elvis.yourdomain.com
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
     "@prisma/client": "5.22.0",
     "axios": "^1.6.5",
     "bullmq": "^5.0.0",
+    "cors": "^2.8.6",
     "date-fns": "^2.30.0",
     "date-fns-tz": "^2.0.0",
     "dotenv": "^17.3.1",
@@ -27,6 +28,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/express": "^4.17.21",
     "@types/multer": "^2.1.0",
     "@types/node": "^20.10.6",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import cors from 'cors';
 import healthRouter from './routes/health';
 import statusRouter from './routes/status';
 import tasksRouter from './routes/tasks';
@@ -12,6 +13,7 @@ import userRouter from './routes/user';
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+app.use(cors({ origin: process.env.CORS_ORIGIN ?? false }));
 app.use(express.json());
 app.use('/', healthRouter);
 app.use('/', statusRouter);

--- a/apps/api/src/routes/__tests__/email.test.ts
+++ b/apps/api/src/routes/__tests__/email.test.ts
@@ -24,6 +24,7 @@ vi.mock('../../lib/prisma', () => ({
     auditLog: {
       create: vi.fn(),
     },
+    $transaction: vi.fn(),
   },
 }));
 
@@ -42,6 +43,13 @@ describe('Email Routes', () => {
     vi.clearAllMocks();
     delete process.env.DRY_RUN;
     delete process.env.SEND_ENABLED;
+
+    // $transaction mock: interactive form passes prisma itself as tx so that
+    // mockResolvedValue setups on prisma.communication/auditLog are picked up.
+    (prisma.$transaction as any).mockImplementation((arg: any) => {
+      if (typeof arg === 'function') return arg(prisma);
+      return Promise.all(arg);
+    });
   });
 
   // ─── POST /email/summary ─────────────────────────────────────────────────

--- a/apps/api/src/routes/email.ts
+++ b/apps/api/src/routes/email.ts
@@ -44,26 +44,30 @@ router.post('/email/draft', async (req, res) => {
   const { provider, to, subject, body, thread_id } = parsed.data;
 
   try {
-    const comm = await prisma.communication.create({
-      data: {
-        provider,
-        type: 'DRAFT',
-        to,
-        subject,
-        body,
-        thread_id: thread_id ?? null,
-        status: 'AWAITING_APPROVAL',
-      },
-    });
+    const comm = await prisma.$transaction(async (tx) => {
+      const created = await tx.communication.create({
+        data: {
+          provider,
+          type: 'DRAFT',
+          to,
+          subject,
+          body,
+          thread_id: thread_id ?? null,
+          status: 'AWAITING_APPROVAL',
+        },
+      });
 
-    await prisma.auditLog.create({
-      data: {
-        actor: 'user',
-        action: 'email.draft',
-        entity_type: 'Communication',
-        entity_id: comm.id,
-        summary: `Draft created for ${to}`,
-      },
+      await tx.auditLog.create({
+        data: {
+          actor: 'user',
+          action: 'email.draft',
+          entity_type: 'Communication',
+          entity_id: created.id,
+          summary: `Draft created for ${to}`,
+        },
+      });
+
+      return created;
     });
 
     res.json({
@@ -112,19 +116,21 @@ router.post('/email/send', async (req, res) => {
   const isDryRun = process.env.DRY_RUN === 'true';
 
   if (isDryRun) {
-    await prisma.communication.update({
-      where: { id: comm.id },
-      data: { status: 'DRY_RUN' },
-    });
-    await prisma.auditLog.create({
-      data: {
-        actor: 'user',
-        action: 'email.dry_run',
-        entity_type: 'Communication',
-        entity_id: comm.id,
-        summary: `Dry-run send to ${comm.to}`,
-      },
-    });
+    await prisma.$transaction([
+      prisma.communication.update({
+        where: { id: comm.id },
+        data: { status: 'DRY_RUN' },
+      }),
+      prisma.auditLog.create({
+        data: {
+          actor: 'user',
+          action: 'email.dry_run',
+          entity_type: 'Communication',
+          entity_id: comm.id,
+          summary: `Dry-run send to ${comm.to}`,
+        },
+      }),
+    ]);
     res.json({ status: 'dry_run', would_send_to: comm.to });
     return;
   }
@@ -137,20 +143,21 @@ router.post('/email/send', async (req, res) => {
       await gmailClient.sendEmail(comm.to!, comm.subject!, comm.body!);
     }
 
-    await prisma.communication.update({
-      where: { id: comm.id },
-      data: { status: 'SENT', approved_at: new Date() },
-    });
-
-    await prisma.auditLog.create({
-      data: {
-        actor: 'user',
-        action: 'email.sent',
-        entity_type: 'Communication',
-        entity_id: comm.id,
-        summary: `Email sent to ${comm.to}`,
-      },
-    });
+    await prisma.$transaction([
+      prisma.communication.update({
+        where: { id: comm.id },
+        data: { status: 'SENT', approved_at: new Date() },
+      }),
+      prisma.auditLog.create({
+        data: {
+          actor: 'user',
+          action: 'email.sent',
+          entity_type: 'Communication',
+          entity_id: comm.id,
+          summary: `Email sent to ${comm.to}`,
+        },
+      }),
+    ]);
 
     res.json({ status: 'sent', communication_id: comm.id });
   } catch (err) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       bullmq:
         specifier: ^5.0.0
         version: 5.70.4
+      cors:
+        specifier: ^2.8.6
+        version: 2.8.6
       date-fns:
         specifier: ^2.30.0
         version: 2.30.0
@@ -76,6 +79,9 @@ importers:
         specifier: ^3.22.4
         version: 3.25.76
     devDependencies:
+      '@types/cors':
+        specifier: ^2.8.19
+        version: 2.8.19
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -889,6 +895,9 @@ packages:
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
 
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1286,6 +1295,10 @@ packages:
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -1943,6 +1956,10 @@ packages:
   node-wav@0.0.2:
     resolution: {integrity: sha512-M6Rm/bbG6De/gKGxOpeOobx/dnGuP0dz40adqx38boqHhlWssBJZgLCPBNtb9NkrmnKYiV04xELq+R6PFOnoLA==}
     engines: {node: '>=4.4.0'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -3028,6 +3045,10 @@ snapshots:
 
   '@types/cookiejar@2.1.5': {}
 
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 20.19.37
+
   '@types/estree@1.0.8': {}
 
   '@types/express-serve-static-core@4.19.8':
@@ -3504,6 +3525,11 @@ snapshots:
   cookie@0.7.2: {}
 
   cookiejar@2.1.4: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   create-require@1.1.1: {}
 
@@ -4251,6 +4277,8 @@ snapshots:
 
   node-wav@0.0.2:
     optional: true
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 


### PR DESCRIPTION
## Resumo

Resolve as violações de arquitetura apontadas pelo Jules em #16 e #17 — reimplementadas corretamente após análise de causa raiz.

- **CORS (Ação 3 — #16):** Não fizemos merge do PR original (wildcard `*` inseguro). Implementamos `origin: process.env.CORS_ORIGIN ?? false` — desabilitado por padrão para proteger a API server-to-server, habilitável via env var quando o admin web existir.
- **`$transaction` (Ação 4 — #17):** `communication.create + auditLog.create` (POST /email/draft) e `communication.update + auditLog.create` (POST /email/send) envolvidos em `prisma.$transaction()` para garantir atomicidade e cumprir o invariante Audit-Log Imutável.

Closes #16
Closes #17

## Test plan

- [ ] `pnpm --filter api exec vitest run src/routes/__tests__/email.test.ts` — 21 testes passando
- [ ] Verificar que `CORS_ORIGIN` está documentado em `.env.prod.example`
- [ ] Confirmar que `apps/api/src/index.ts` usa `cors({ origin: process.env.CORS_ORIGIN ?? false })`

🤖 Generated with [Claude Code](https://claude.com/claude-code)