### PR TITLE
Integrate Outlook Calendar into Daily Briefing

### DIFF
--- a/apps/api/src/lib/graphClient.ts
+++ b/apps/api/src/lib/graphClient.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
 import { getToken } from './oauthService';
+export { getCalendarEventsForToday, type CalendarEvent } from '@elvis/shared';
 
 /**
  * Creates an axios instance configured for Microsoft Graph API calls.

--- a/apps/api/src/lib/graphClient.ts
+++ b/apps/api/src/lib/graphClient.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
 import { getToken } from './oauthService';
-export { getCalendarEventsForToday, type CalendarEvent } from '@elvis/shared';
+export { getCalendarEventsForToday, type CalendarEvent } from '@shared';
 
 /**
  * Creates an axios instance configured for Microsoft Graph API calls.

--- a/apps/worker/src/jobs/__tests__/briefing.test.ts
+++ b/apps/worker/src/jobs/__tests__/briefing.test.ts
@@ -3,7 +3,7 @@ import { briefingJob } from '../briefing';
 import prisma from '../../lib/prisma';
 import { sendMessage } from '../../lib/messenger';
 import { getToken } from '../../lib/oauthService';
-import { getCalendarEventsForToday } from '@elvis/shared';
+import { getCalendarEventsForToday } from '@shared';
 
 vi.mock('../../lib/prisma', () => ({
   default: {
@@ -32,7 +32,7 @@ vi.mock('../../lib/oauthService', () => ({
   getToken: vi.fn(),
 }));
 
-vi.mock('@elvis/shared', () => ({
+vi.mock('@shared', () => ({
   getCalendarEventsForToday: vi.fn(),
 }));
 
@@ -52,7 +52,6 @@ describe('briefingJob', () => {
   it('AC1: sends briefing with events when token and events exist', async () => {
     (getToken as any).mockResolvedValue('valid-token');
 
-    // Using ISO strings with explicit offset to avoid test failures due to local timezone
     (getCalendarEventsForToday as any).mockResolvedValue([
       {
         title: 'Reunião com cliente',

--- a/apps/worker/src/jobs/__tests__/briefing.test.ts
+++ b/apps/worker/src/jobs/__tests__/briefing.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { briefingJob } from '../briefing';
+import prisma from '../../lib/prisma';
+import { sendMessage } from '../../lib/messenger';
+import { getToken } from '../../lib/oauthService';
+import { getCalendarEventsForToday } from '@elvis/shared';
+
+vi.mock('../../lib/prisma', () => ({
+  default: {
+    userProfile: {
+      findFirst: vi.fn(),
+    },
+    auditLog: {
+      count: vi.fn(),
+      create: vi.fn(),
+    },
+    task: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../../lib/messenger', () => ({
+  sendMessage: vi.fn(),
+}));
+
+vi.mock('../../lib/quietHours', () => ({
+  isQuietHours: vi.fn(() => false),
+}));
+
+vi.mock('../../lib/oauthService', () => ({
+  getToken: vi.fn(),
+}));
+
+vi.mock('@elvis/shared', () => ({
+  getCalendarEventsForToday: vi.fn(),
+}));
+
+describe('briefingJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.OWNER_PHONE = '551199999999';
+    process.env.OAUTH_ENC_KEY = '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff';
+
+    (prisma.userProfile.findFirst as any).mockResolvedValue({
+      daily_nudge_limit: 5,
+    });
+    (prisma.auditLog.count as any).mockResolvedValue(0);
+    (prisma.task.findMany as any).mockResolvedValue([]);
+  });
+
+  it('AC1: sends briefing with events when token and events exist', async () => {
+    (getToken as any).mockResolvedValue('valid-token');
+
+    // Using ISO strings with explicit offset to avoid test failures due to local timezone
+    (getCalendarEventsForToday as any).mockResolvedValue([
+      {
+        title: 'Reunião com cliente',
+        start: '2024-01-01T12:00:00Z', // 09:00 BRT
+        end: '2024-01-01T13:00:00Z',
+        durationText: '1h',
+      },
+      {
+        title: 'Almoço com João',
+        start: '2024-01-01T17:00:00Z', // 14:00 BRT
+        end: '2024-01-01T18:00:00Z',
+        durationText: '1h',
+      },
+    ]);
+
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+
+    (prisma.task.findMany as any).mockResolvedValue([
+      { id: '1', title: 'Revisar proposta', priority: 'URGENT', status: 'PENDING', due_at: null },
+      { id: '2', title: 'Confirmar reunião', priority: 'HIGH', status: 'PENDING', due_at: new Date() },
+      { id: '3', title: 'Longe', priority: 'LOW', status: 'PENDING', due_at: tomorrow },
+    ]);
+
+    await briefingJob();
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      '551199999999',
+      expect.stringContaining('📅 Compromissos de hoje:')
+    );
+    expect(sendMessage).toHaveBeenCalledWith(
+      '551199999999',
+      expect.stringContaining('• 09:00 — Reunião com cliente (1h)')
+    );
+    expect(sendMessage).toHaveBeenCalledWith(
+      '551199999999',
+      expect.stringContaining('• 14:00 — Almoço com João (1h)')
+    );
+    expect(sendMessage).toHaveBeenCalledWith(
+      '551199999999',
+      expect.stringContaining('✅ Tarefas: 0 atrasadas · 2 urgentes')
+    );
+    expect(sendMessage).toHaveBeenCalledWith(
+      '551199999999',
+      expect.stringContaining('Top 3: Revisar proposta · Confirmar reunião')
+    );
+  });
+
+  it('AC2: omits calendar section when no events exist', async () => {
+    (getToken as any).mockResolvedValue('valid-token');
+    (getCalendarEventsForToday as any).mockResolvedValue([]);
+
+    await briefingJob();
+
+    const text = (sendMessage as any).mock.calls[0][1];
+    expect(text).not.toContain('📅 Compromissos de hoje:');
+    expect(text).toContain('✅ Tarefas:');
+  });
+
+  it('AC3: sends briefing with warning when token is missing', async () => {
+    (getToken as any).mockResolvedValue(null);
+
+    await briefingJob();
+
+    const text = (sendMessage as any).mock.calls[0][1];
+    expect(text).toContain('📅 Calendário não configurado. Execute o OAuth bootstrap no servidor para habilitar.');
+    expect(text).toContain('✅ Tarefas:');
+  });
+
+  it('AC3 Fallback: sends briefing with warning when graphClient throws error', async () => {
+    (getToken as any).mockResolvedValue('valid-token');
+    (getCalendarEventsForToday as any).mockRejectedValue(new Error('OAuth error'));
+
+    await briefingJob();
+
+    const text = (sendMessage as any).mock.calls[0][1];
+    expect(text).toContain('📅 Calendário não configurado. Execute o OAuth bootstrap no servidor para habilitar.');
+    expect(text).toContain('✅ Tarefas:');
+  });
+});

--- a/apps/worker/src/jobs/briefing.ts
+++ b/apps/worker/src/jobs/briefing.ts
@@ -3,7 +3,7 @@ import { isQuietHours } from '../lib/quietHours';
 import { sendMessage } from '../lib/messenger';
 import { utcToZonedTime, format as formatTz } from 'date-fns-tz';
 import { getToken } from '../lib/oauthService';
-import { getCalendarEventsForToday } from '@elvis/shared';
+import { getCalendarEventsForToday } from '@shared';
 
 export async function briefingJob(): Promise<void> {
   const ownerPhone = process.env.OWNER_PHONE || '551199999999';

--- a/apps/worker/src/jobs/briefing.ts
+++ b/apps/worker/src/jobs/briefing.ts
@@ -1,8 +1,9 @@
 import prisma from '../lib/prisma';
 import { isQuietHours } from '../lib/quietHours';
 import { sendMessage } from '../lib/messenger';
-import { format } from 'date-fns';
-import { utcToZonedTime } from 'date-fns-tz';
+import { utcToZonedTime, format as formatTz } from 'date-fns-tz';
+import { getToken } from '../lib/oauthService';
+import { getCalendarEventsForToday } from '@elvis/shared';
 
 export async function briefingJob(): Promise<void> {
   const ownerPhone = process.env.OWNER_PHONE || '551199999999';
@@ -20,8 +21,9 @@ export async function briefingJob(): Promise<void> {
     return;
   }
 
-  // Check daily nudge count (naive: count today's audit logs with action containing "nudge")
-  const today = utcToZonedTime(new Date(), 'America/Sao_Paulo');
+  // Check daily nudge count
+  const timezone = 'America/Sao_Paulo';
+  const today = utcToZonedTime(new Date(), timezone);
   const startOfDay = new Date(today.getFullYear(), today.getMonth(), today.getDate());
   const endOfDay = new Date(startOfDay);
   endOfDay.setDate(endOfDay.getDate() + 1);
@@ -39,7 +41,30 @@ export async function briefingJob(): Promise<void> {
     return;
   }
 
-  // Get today's data (overdue + urgent tasks)
+  // 1. Calendar Events
+  let calendarText = '';
+  let calendarWarning = '';
+  try {
+    const token = await getToken();
+    if (token) {
+      const events = await getCalendarEventsForToday(token);
+      if (events.length > 0) {
+        calendarText = '📅 Compromissos de hoje:\n' +
+          events.map(e => {
+            const zonedStart = utcToZonedTime(new Date(e.start), timezone);
+            const startTime = formatTz(zonedStart, 'HH:mm', { timeZone: timezone });
+            return `• ${startTime} — ${e.title} (${e.durationText})`;
+          }).join('\n') + '\n\n';
+      }
+    } else {
+      calendarWarning = '📅 Calendário não configurado. Execute o OAuth bootstrap no servidor para habilitar.\n\n';
+    }
+  } catch (error) {
+    console.error('Error fetching calendar events:', error);
+    calendarWarning = '📅 Calendário não configurado. Execute o OAuth bootstrap no servidor para habilitar.\n\n';
+  }
+
+  // 2. Tasks
   const tasks = await prisma.task.findMany({
     where: { status: { in: ['PENDING', 'IN_PROGRESS'] } },
   });
@@ -52,13 +77,18 @@ export async function briefingJob(): Promise<void> {
       (t.due_at && t.due_at >= todayDate && t.due_at < endOfDay)
   );
 
-  const top3 = [...overdue, ...urgent].slice(0, 3);
-  const topText =
-    top3.length > 0
-      ? top3.map((t) => `• ${t.title}`).join('\n')
-      : '(nenhuma)';
+  // Deduplicate and get top 3
+  const combined = [...overdue, ...urgent];
+  const uniqueTasks = combined.filter((v, i, a) => a.findIndex(t => t.id === v.id) === i);
+  const top3 = uniqueTasks.slice(0, 3);
 
-  const text = `Bom dia! ☀️\n\nResumo do dia:\n• ${overdue.length} atrasados\n• ${urgent.length} urgentes\n\nTop 3:\n${topText}`;
+  const top3Text = top3.length > 0
+    ? `Top 3: ${top3.map(t => t.title).join(' · ')}`
+    : 'Top 3: (nenhuma)';
+
+  const tasksText = `✅ Tarefas: ${overdue.length} atrasadas · ${urgent.length} urgentes\n${top3Text}`;
+
+  const text = `Bom dia! ☀️\n${calendarText}${calendarWarning}${tasksText}`;
 
   await sendMessage(ownerPhone, text);
 

--- a/apps/worker/src/lib/oauthService.ts
+++ b/apps/worker/src/lib/oauthService.ts
@@ -1,0 +1,68 @@
+import * as crypto from 'crypto';
+import prisma from './prisma';
+
+/**
+ * Decrypts a token encrypted with AES-256-GCM
+ * Expects format: "iv:ciphertextAuthTag"
+ */
+function decryptToken(encryptedBlob: string, key: Buffer): string {
+  const [ivHex, ciphertextWithTag] = encryptedBlob.split(':');
+
+  if (!ivHex || !ciphertextWithTag) {
+    throw new Error('Invalid encrypted blob format');
+  }
+
+  const iv = Buffer.from(ivHex, 'hex');
+
+  // Last 32 hex chars = 16 bytes = 128-bit auth tag
+  const authTagHex = ciphertextWithTag.slice(-32);
+  const ciphertextHex = ciphertextWithTag.slice(0, -32);
+
+  const authTag = Buffer.from(authTagHex, 'hex');
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(authTag);
+
+  let decrypted = decipher.update(ciphertextHex, 'hex', 'utf8');
+  decrypted += decipher.final('utf8');
+
+  return decrypted;
+}
+
+/**
+ * Get encryption key from OAUTH_ENC_KEY environment variable
+ * Expected format: 64-char hex string (32 bytes)
+ */
+function getEncryptionKey(): Buffer {
+  const keyHex = process.env.OAUTH_ENC_KEY;
+  if (!keyHex) {
+    throw new Error('OAUTH_ENC_KEY environment variable not set');
+  }
+
+  if (keyHex.length !== 64) {
+    throw new Error('OAUTH_ENC_KEY must be 64 hex characters (32 bytes)');
+  }
+
+  return Buffer.from(keyHex, 'hex');
+}
+
+/**
+ * Retrieve and decrypt the Microsoft OAuth token from the database.
+ * Returns null if no token is stored.
+ */
+export async function getToken(): Promise<string | null> {
+  const record = await prisma.oAuthToken.findUnique({
+    where: { provider: 'MICROSOFT' },
+  });
+
+  if (!record) {
+    return null;
+  }
+
+  try {
+    const key = getEncryptionKey();
+    return decryptToken(record.encrypted_token_blob, key);
+  } catch (error) {
+    console.error('Error decrypting Microsoft token:', error);
+    return null;
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,2 @@
 export * from './whatsapp';
+export * from './services/graphClient';

--- a/packages/shared/src/services/graphClient.ts
+++ b/packages/shared/src/services/graphClient.ts
@@ -1,0 +1,74 @@
+import axios from 'axios';
+
+export interface CalendarEvent {
+  title: string;
+  start: string;
+  end: string;
+  durationText: string;
+}
+
+/**
+ * Fetches calendar events for the current day from Microsoft Graph.
+ * @param accessToken Microsoft OAuth access token
+ * @returns List of events with title, start, end, and duration
+ */
+export async function getCalendarEventsForToday(accessToken: string): Promise<CalendarEvent[]> {
+  // Calculate start and end of today in America/Sao_Paulo
+  // Since we might not have date-fns-tz in shared, we use a simple approach
+  const now = new Date();
+
+  // Brazil/Sao Paulo is UTC-3 (ignoring DST as it's currently not used in Brazil)
+  const offset = -3;
+  const brNow = new Date(now.getTime() + (offset * 60 * 60 * 1000));
+
+  const startOfDay = new Date(brNow);
+  startOfDay.setUTCHours(0, 0, 0, 0);
+  // Adjust back to UTC for the API call
+  const startDateTime = new Date(startOfDay.getTime() - (offset * 60 * 60 * 1000)).toISOString();
+
+  const endOfDay = new Date(startOfDay);
+  endOfDay.setUTCHours(23, 59, 59, 999);
+  const endDateTime = new Date(endOfDay.getTime() - (offset * 60 * 60 * 1000)).toISOString();
+
+  const response = await axios.get('https://graph.microsoft.com/v1.0/me/calendarview', {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Prefer': 'outlook.timezone="America/Sao_Paulo"'
+    },
+    params: {
+      startDateTime,
+      endDateTime,
+      '$select': 'subject,start,end',
+      '$orderby': 'start/dateTime',
+    },
+  });
+
+  return response.data.value.map((event: any) => {
+    const start = new Date(event.start.dateTime);
+    const end = new Date(event.end.dateTime);
+    const durationMs = end.getTime() - start.getTime();
+    const durationMin = Math.round(durationMs / (1000 * 60));
+    const hours = Math.floor(durationMin / 60);
+    const minutes = durationMin % 60;
+
+    let durationText = '';
+    if (hours > 0) {
+      durationText += `${hours}h`;
+    }
+    if (minutes > 0 || (hours === 0)) {
+      durationText += `${minutes}min`;
+    }
+
+    // Clean up durationText if it's just e.g. "1h0min" to "1h"
+    if (durationText.endsWith('0min') && hours > 0) {
+      durationText = durationText.replace('0min', '');
+    }
+
+    return {
+      title: event.subject,
+      start: event.start.dateTime,
+      end: event.end.dateTime,
+      durationText
+    };
+  });
+}

--- a/packages/shared/src/services/graphClient.ts
+++ b/packages/shared/src/services/graphClient.ts
@@ -13,17 +13,14 @@ export interface CalendarEvent {
  * @returns List of events with title, start, end, and duration
  */
 export async function getCalendarEventsForToday(accessToken: string): Promise<CalendarEvent[]> {
-  // Calculate start and end of today in America/Sao_Paulo
-  // Since we might not have date-fns-tz in shared, we use a simple approach
   const now = new Date();
 
-  // Brazil/Sao Paulo is UTC-3 (ignoring DST as it's currently not used in Brazil)
+  // Brazil/Sao Paulo is UTC-3
   const offset = -3;
   const brNow = new Date(now.getTime() + (offset * 60 * 60 * 1000));
 
   const startOfDay = new Date(brNow);
   startOfDay.setUTCHours(0, 0, 0, 0);
-  // Adjust back to UTC for the API call
   const startDateTime = new Date(startOfDay.getTime() - (offset * 60 * 60 * 1000)).toISOString();
 
   const endOfDay = new Date(startOfDay);
@@ -33,7 +30,7 @@ export async function getCalendarEventsForToday(accessToken: string): Promise<Ca
   const response = await axios.get('https://graph.microsoft.com/v1.0/me/calendarview', {
     headers: {
       Authorization: `Bearer ${accessToken}`,
-      'Prefer': 'outlook.timezone="America/Sao_Paulo"'
+      // We don't set outlook.timezone Prefer header to get UTC times
     },
     params: {
       startDateTime,
@@ -59,15 +56,16 @@ export async function getCalendarEventsForToday(accessToken: string): Promise<Ca
       durationText += `${minutes}min`;
     }
 
-    // Clean up durationText if it's just e.g. "1h0min" to "1h"
     if (durationText.endsWith('0min') && hours > 0) {
       durationText = durationText.replace('0min', '');
     }
 
+    // graph.microsoft.com/v1.0/me/calendarview returns UTC by default if no Prefer header is present
+    // but to be safe we ensure the date objects are correctly initialized from the response strings
     return {
       title: event.subject,
-      start: event.start.dateTime,
-      end: event.end.dateTime,
+      start: event.start.dateTime.endsWith('Z') ? event.start.dateTime : `${event.start.dateTime}Z`,
+      end: event.end.dateTime.endsWith('Z') ? event.end.dateTime : `${event.end.dateTime}Z`,
       durationText
     };
   });

--- a/task.md
+++ b/task.md
@@ -275,7 +275,7 @@ bash scripts/backup.sh && ls backups/  # → arquivo .dump de hoje
 > **Contexto:** Em 2026-04-09, a hipótese central do MVP foi validada: o comando `SEND_TO` existe e funciona (ex: "manda para assistente: já terminei a reunião"). No entanto, o `ai-blueprints.md` exige `approval_record_id` antes de qualquer escrita externa, e o WhatsApp envia imediatamente sem approval gate — violando a Invariante #1. M10 corrige essa lacuna trazendo WhatsApp para paridade com o fluxo de e-mail.
 
 - [ ] Quando `SEND_TO` é acionado, criar registro `Communication` (status: `AWAITING_APPROVAL`, channel: `WHATSAPP`)
-- [ ] Responder ao owner com preview: _"Vou mandar para [nome]: '[msg]'. Confirma? /confirm [id] ou /cancel [id]"_
+- [ ] Responder ao owner with preview: _"Vou mandar para [nome]: '[msg]'. Confirma? /confirm [id] ou /cancel [id]"_
 - [ ] Implementar intent `CONFIRM` no commandParser (ex: "/confirm 42")
 - [ ] Implementar intent `CANCEL` no commandParser (ex: "/cancel 42")
 - [ ] Só enviar a mensagem real após `/confirm` — verificar `approval_record_id` no banco
@@ -437,3 +437,4 @@ pnpm lint && pnpm build
 | 2026-04-10 | M11 [COWORK] concluído: Contact table + migration, contactService, llmService (Groq), ALIAS_SHORTCUT, aprendizado semântico de atalhos — **175 testes passando** ✅ |
 | 2026-04-17 | Performance: Moved dayMap instantiation outside resolveDate in webhook.ts to reduce GC pressure.
 | 2026-04-11 | PDLC [COWORK] concluído: Automação upstream via marcadores HTML e trigger do Jules para `spec:approved` — **231 testes passando** ✅ |
+| 2026-04-18 | Briefing [COWORK] concluído: Integrou eventos do calendário Outlook ao briefing diário (07:30) com fallback OAuth e formatação pt-BR — **235 testes passando** ✅ |

--- a/task.md
+++ b/task.md
@@ -275,7 +275,7 @@ bash scripts/backup.sh && ls backups/  # → arquivo .dump de hoje
 > **Contexto:** Em 2026-04-09, a hipótese central do MVP foi validada: o comando `SEND_TO` existe e funciona (ex: "manda para assistente: já terminei a reunião"). No entanto, o `ai-blueprints.md` exige `approval_record_id` antes de qualquer escrita externa, e o WhatsApp envia imediatamente sem approval gate — violando a Invariante #1. M10 corrige essa lacuna trazendo WhatsApp para paridade com o fluxo de e-mail.
 
 - [ ] Quando `SEND_TO` é acionado, criar registro `Communication` (status: `AWAITING_APPROVAL`, channel: `WHATSAPP`)
-- [ ] Responder ao owner with preview: _"Vou mandar para [nome]: '[msg]'. Confirma? /confirm [id] ou /cancel [id]"_
+- [ ] Responder ao owner com preview: _"Vou mandar para [nome]: '[msg]'. Confirma? /confirm [id] ou /cancel [id]"_
 - [ ] Implementar intent `CONFIRM` no commandParser (ex: "/confirm 42")
 - [ ] Implementar intent `CANCEL` no commandParser (ex: "/cancel 42")
 - [ ] Só enviar a mensagem real após `/confirm` — verificar `approval_record_id` no banco
@@ -437,4 +437,3 @@ pnpm lint && pnpm build
 | 2026-04-10 | M11 [COWORK] concluído: Contact table + migration, contactService, llmService (Groq), ALIAS_SHORTCUT, aprendizado semântico de atalhos — **175 testes passando** ✅ |
 | 2026-04-17 | Performance: Moved dayMap instantiation outside resolveDate in webhook.ts to reduce GC pressure.
 | 2026-04-11 | PDLC [COWORK] concluído: Automação upstream via marcadores HTML e trigger do Jules para `spec:approved` — **231 testes passando** ✅ |
-| 2026-04-18 | Briefing [COWORK] concluído: Integrou eventos do calendário Outlook ao briefing diário (07:30) com fallback OAuth e formatação pt-BR — **235 testes passando** ✅ |


### PR DESCRIPTION
This PR integrates Microsoft Outlook calendar events into the daily briefing WhatsApp message sent at 07:30. 

Key changes:
- New `getCalendarEventsForToday` service in `@elvis/shared`.
- Secure token retrieval and decryption in `apps/worker`.
- Updated `briefingJob` with the requested message format and logic.
- Robust error handling and fallback for OAuth issues.
- Comprehensive unit tests in `apps/worker/src/jobs/__tests__/briefing.test.ts`.

Verification:
- `pnpm --filter worker exec vitest run src/jobs/__tests__/briefing.test.ts` (All 4 tests passed)
- `pnpm --filter api exec vitest run` (All 231 tests passed)

Fixes #39

---
*PR created automatically by Jules for task [4958877816099776883](https://jules.google.com/task/4958877816099776883) started by @rafaeltcosta86*