### PR TITLE
Add /tarefas command to list open tasks

### DIFF
--- a/apps/api/src/lib/commandParser.ts
+++ b/apps/api/src/lib/commandParser.ts
@@ -14,6 +14,7 @@ export type Intent =
   | 'ALIAS_SHORTCUT'
   | 'CREATE_EVENT'
   | 'LIST_CONTACTS'
+  | 'LIST_TASKS'
   | 'UNKNOWN';
 
 export interface ParsedCommand {
@@ -35,6 +36,11 @@ export function parseCommand(text: string): ParsedCommand {
   // /contatos
   if (/^\/contatos$/i.test(trimmed)) {
     return { intent: 'LIST_CONTACTS' };
+  }
+
+  // /tarefas
+  if (/^\/tarefas$/i.test(trimmed)) {
+    return { intent: 'LIST_TASKS' };
   }
 
   // /hoje

--- a/apps/api/src/routes/__tests__/list_tasks.test.ts
+++ b/apps/api/src/routes/__tests__/list_tasks.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../lib/prisma', () => ({
+  default: {
+    task: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn(),
+    },
+    userProfile: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    auditLog: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+    },
+    communication: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../../lib/nanoclawClient', () => ({
+  sendWhatsApp: vi.fn(),
+}));
+
+vi.mock('../../lib/emailService', () => ({
+  getEmailSummary: vi.fn(),
+}));
+
+vi.mock('../../lib/contactService', () => ({
+  findByAlias: vi.fn(),
+  findByName: vi.fn().mockResolvedValue(null),
+  addAlias: vi.fn(),
+  listContacts: vi.fn(),
+}));
+
+vi.mock('../../lib/llmService', () => ({
+  classifyIntent: vi.fn(),
+  suggestAction: vi.fn(),
+  normalizeAudioCommand: vi.fn(),
+}));
+
+vi.mock('../../lib/oauthService', () => ({
+  getToken: vi.fn(),
+}));
+
+vi.mock('../../lib/redis', () => ({
+  default: { set: vi.fn().mockResolvedValue('OK'), get: vi.fn().mockResolvedValue(null), del: vi.fn().mockResolvedValue(1) },
+}));
+
+import webhookRouter from '../webhook';
+import { sendWhatsApp } from '../../lib/nanoclawClient';
+import prisma from '../../lib/prisma';
+
+const app = express();
+app.use(express.json());
+app.use('/', webhookRouter);
+
+const WEBHOOK_SECRET = 'test-secret';
+
+function webhookPost(messageText: string) {
+  return request(app)
+    .post('/webhook/nanoclaw')
+    .set('Authorization', `Bearer ${WEBHOOK_SECRET}`)
+    .send({
+      sender_id: '551199999999',
+      message_text: messageText,
+      message_id: 'msg-001',
+      timestamp: 1700000000,
+    });
+}
+
+describe('Webhook — LIST_TASKS (/tarefas)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.WEBHOOK_SECRET = WEBHOOK_SECRET;
+    (sendWhatsApp as any).mockResolvedValue(undefined);
+  });
+
+  it('retorna mensagem de lista vazia quando não há tarefas abertas', async () => {
+    (prisma.task.findMany as any).mockResolvedValue([]);
+
+    await webhookPost('/tarefas');
+
+    const sentText: string = (sendWhatsApp as any).mock.calls[0][1];
+    expect(sentText).toBe('Nenhuma tarefa pendente, pode relaxar! 😎');
+  });
+
+  it('retorna lista de tarefas formatada e ordenada', async () => {
+    const mockTasks = [
+      { title: 'Tarefa 1', created_at: new Date('2023-01-01') },
+      { title: 'Tarefa 2', created_at: new Date('2023-01-02') },
+    ];
+    (prisma.task.findMany as any).mockResolvedValue(mockTasks);
+
+    await webhookPost('/tarefas');
+
+    expect(prisma.task.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { status: { in: ['PENDING', 'IN_PROGRESS'] } },
+      orderBy: { created_at: 'asc' },
+    }));
+
+    const sentText: string = (sendWhatsApp as any).mock.calls[0][1];
+    expect(sentText).toBe('1. Tarefa 1\n2. Tarefa 2');
+  });
+
+  it('é case-insensitive', async () => {
+    (prisma.task.findMany as any).mockResolvedValue([]);
+
+    await webhookPost('/TAREFAS');
+
+    expect(prisma.task.findMany).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/webhook.ts
+++ b/apps/api/src/routes/webhook.ts
@@ -154,6 +154,23 @@ async function handleIncomingWhatsApp(
         break;
       }
 
+      case 'LIST_TASKS': {
+        const tasks = await prisma.task.findMany({
+          where: { status: { in: ['PENDING', 'IN_PROGRESS'] } },
+          orderBy: { created_at: 'asc' },
+        });
+
+        if (tasks.length === 0) {
+          responseText = 'Nenhuma tarefa pendente, pode relaxar! 😎';
+        } else {
+          const list = tasks
+            .map((t, index) => `${index + 1}. ${t.title}`)
+            .join('\n');
+          responseText = list;
+        }
+        break;
+      }
+
       case 'TODAY': {
         const today = utcToZonedTime(new Date(), TIMEZONE);
         const todayDate = new Date(

--- a/task.md
+++ b/task.md
@@ -437,5 +437,6 @@ pnpm lint && pnpm build
 | 2026-04-10 | M11 [COWORK] concluído: Contact table + migration, contactService, llmService (Groq), ALIAS_SHORTCUT, aprendizado semântico de atalhos — **175 testes passando** ✅ |
 | 2026-04-11 | PDLC [COWORK] concluído: Automação upstream via marcadores HTML e trigger do Jules para `spec:approved` — **231 testes passando** ✅ |
 | 2026-04-17 | Comandos [COWORK] concluído: Adicionado comando `/contatos` para listagem de contatos cadastrados — **235 testes passando** ✅ |
+| 2026-04-17 | Comandos [COWORK] concluído: Adicionado comando `/tarefas` para listagem de tarefas pendentes ordenadas por data de criação — **238 testes passando** ✅ |
 | 2026-04-17 | Performance: Moved dayMap instantiation outside resolveDate in webhook.ts to reduce GC pressure. |
 | 2026-04-17 | Sentinel [COWORK] concluído: Automação de issues architecture-violation para o board PDLC (coluna 💡 Ideia) usando PROJECT_TOKEN. |


### PR DESCRIPTION
This PR adds the `/tarefas` command to Elvis, allowing users to list all open tasks (status PENDING or IN_PROGRESS) ordered from oldest to newest.

Key changes:
- **commandParser.ts**: Added `LIST_TASKS` intent and recognized `/tarefas` (case-insensitive).
- **webhook.ts**: Added logic to handle `LIST_TASKS`. It queries the database for tasks with status `PENDING` or `IN_PROGRESS`, sorted by `created_at` ASC. It returns a numbered list of task titles or a "relax" message if no tasks are found.
- **Tests**: Created `list_tasks.test.ts` to verify the new command, including empty states and case-sensitivity.
- **Log**: Updated `task.md` with the new completed task.

Fixes #55

---
*PR created automatically by Jules for task [5377756290865803692](https://jules.google.com/task/5377756290865803692) started by @rafaeltcosta86*