### PR TITLE
Implement contact deletion via natural language

### DIFF
--- a/apps/api/src/lib/__tests__/contactService.test.ts
+++ b/apps/api/src/lib/__tests__/contactService.test.ts
@@ -8,6 +8,7 @@ vi.mock('../prisma', () => ({
       create: vi.fn(),
       update: vi.fn(),
       findMany: vi.fn(),
+      delete: vi.fn(),
     },
   },
 }));
@@ -20,6 +21,7 @@ import {
   createContact,
   setOwnerAlias,
   listContacts,
+  deleteContact,
 } from '../contactService';
 
 const linic = {
@@ -134,5 +136,16 @@ describe('listContacts', () => {
     (prisma.contact.findMany as any).mockResolvedValue([linic]);
     const result = await listContacts();
     expect(result).toEqual([linic]);
+  });
+});
+
+describe('deleteContact', () => {
+  it('deletes contact by id', async () => {
+    (prisma.contact.delete as any).mockResolvedValue(linic);
+    const result = await deleteContact('c1');
+    expect(prisma.contact.delete).toHaveBeenCalledWith({
+      where: { id: 'c1' },
+    });
+    expect(result).toEqual(linic);
   });
 });

--- a/apps/api/src/lib/__tests__/llmService.test.ts
+++ b/apps/api/src/lib/__tests__/llmService.test.ts
@@ -100,6 +100,17 @@ describe('classifyIntent', () => {
       owner_alias: 'pai',
     });
   });
+
+  it('returns DELETE_CONTACT when user wants to remove a contact', async () => {
+    mockFetch.mockResolvedValue(
+      groqResponse('{"intent":"DELETE_CONTACT","contact_identifier":"Siqueira"}')
+    );
+    const result = await classifyIntent('delete o contato Siqueira');
+    expect(result).toEqual<LLMClassification>({
+      intent: 'DELETE_CONTACT',
+      contact_identifier: 'Siqueira',
+    });
+  });
 });
 
 describe('CREATE_EVENT intent', () => {

--- a/apps/api/src/lib/contactService.ts
+++ b/apps/api/src/lib/contactService.ts
@@ -40,3 +40,7 @@ export async function setOwnerAlias(contactName: string, alias: string): Promise
 export async function listContacts(): Promise<Contact[]> {
   return prisma.contact.findMany();
 }
+
+export async function deleteContact(id: string): Promise<Contact> {
+  return prisma.contact.delete({ where: { id } });
+}

--- a/apps/api/src/lib/llmService.ts
+++ b/apps/api/src/lib/llmService.ts
@@ -3,6 +3,7 @@ export type LLMClassification =
   | { intent: 'CREATE_CONTACT'; contact_name: string; phone: string; owner_alias?: string }
   | { intent: 'SET_OWNER_ALIAS'; contact_name: string; owner_alias: string }
   | { intent: 'CREATE_EVENT'; title: string; date: string; time: string; duration_min: number; contact_name?: string }
+  | { intent: 'DELETE_CONTACT'; contact_identifier: string }
   | { intent: 'UNKNOWN' };
 
 const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
@@ -20,6 +21,10 @@ Analise a mensagem e retorne JSON com UMA destas estruturas:
 - Alteração de como o dono se identifica com um contato: {"intent":"SET_OWNER_ALIAS","contact_name":"<nome>","owner_alias":"<como o dono quer ser chamado>"}
   Use quando pedirem para mudar/alterar/definir como o dono aparece ou se chama para um contato específico.
   Ex: "agora sou o pai pra Estela", "muda meu nome pra Linic para Rafa", "altere a interação com a Amanda para Amor"
+
+- Deleção de contato: {"intent":"DELETE_CONTACT","contact_identifier":"<nome ou alias mencionado>"}
+  Use quando o usuário quiser deletar, remover, apagar ou excluir um contato da lista.
+  Ex: "delete o contato Siqueira", "remove o contato /siqueira", "apaga o contato João da minha lista"
 
 - Criação de evento no calendário: {"intent":"CREATE_EVENT","title":"<título do evento>","date":"<data no formato YYYY-MM-DD ou relativa como 'quinta','amanhã','sexta'>","time":"<hora no formato HH:MM>","duration_min":<duração em minutos, padrão 60>,"contact_name":"<opcional: nome do participante>"}
   Use quando o usuário quiser agendar, marcar, criar uma reunião, evento, compromisso ou lembrança com hora.
@@ -184,6 +189,9 @@ export async function classifyIntent(text: string): Promise<LLMClassification> {
         duration_min: typeof parsed.duration_min === 'number' ? parsed.duration_min : 60,
         ...(parsed.contact_name ? { contact_name: String(parsed.contact_name) } : {}),
       };
+    }
+    if (parsed.intent === 'DELETE_CONTACT' && parsed.contact_identifier) {
+      return { intent: 'DELETE_CONTACT', contact_identifier: String(parsed.contact_identifier) };
     }
     return { intent: 'UNKNOWN' };
   } catch {

--- a/apps/api/src/routes/webhook.ts
+++ b/apps/api/src/routes/webhook.ts
@@ -15,6 +15,7 @@ import {
   createContact,
   setOwnerAlias,
   listContacts,
+  deleteContact,
 } from '../lib/contactService';
 import { classifyIntent, suggestAction, normalizeAudioCommand } from '../lib/llmService';
 import { getToken } from '../lib/oauthService';
@@ -94,6 +95,10 @@ function eventPreview(title: string, startISO: string, durationMin: number): str
   const [datePart, timePart] = startISO.split('T');
   const time = (timePart ?? '').substring(0, 5);
   return `📅 Vou marcar:\n*${title}*\n${datePart} às ${time} (${durationMin}min)\n\n1️⃣ Confirmar  |  2️⃣ Cancelar`;
+}
+
+function deleteContactPreview(name: string, alias: string, phone: string): string {
+  return `🗑️ Confirmar deleção?\n\nNome: ${name}\nAlias: ${alias}\nTelefone: ${phone}\n\n1️⃣ Confirmar  |  2️⃣ Cancelar`;
 }
 
 // Parse WHATSAPP_CONTACTS=nome:numero,nome2:numero2
@@ -364,6 +369,39 @@ async function handleIncomingWhatsApp(
           break;
         }
 
+        if (classification.intent === 'DELETE_CONTACT') {
+          const identifier = classification.contact_identifier;
+          const contact = identifier.startsWith('/')
+            ? await findByAlias(identifier)
+            : await findByName(identifier);
+
+          if (!contact) {
+            responseText = `❌ Não encontrei nenhum contato com esse nome ou alias. Verifique com /contatos.`;
+            break;
+          }
+
+          const alias = contact.aliases[0] || '';
+          const formattedAlias = alias.startsWith('/') ? alias : `/${alias}`;
+
+          const comm = await prisma.communication.create({
+            data: {
+              provider: 'WHATSAPP',
+              type: 'DRAFT',
+              to: null,
+              body: null,
+              status: 'AWAITING_APPROVAL',
+              metadata: {
+                kind: 'DELETE_CONTACT',
+                contactId: contact.id,
+                contactName: contact.name,
+              },
+            },
+          });
+          await savePending(sender_id, comm.id);
+          responseText = deleteContactPreview(contact.name, formattedAlias, contact.phone);
+          break;
+        }
+
         const newTask = await prisma.task.create({
           data: {
             title: args?.rawText || 'Sem título',
@@ -482,6 +520,27 @@ async function handleIncomingWhatsApp(
           break;
         }
 
+        if (confirmMeta?.kind === 'DELETE_CONTACT') {
+          const { contactId, contactName } = confirmMeta as { contactId: string; contactName: string };
+          await deleteContact(contactId);
+          await prisma.communication.update({
+            where: { id: comm.id },
+            data: { status: 'SENT', approved_at: new Date() },
+          });
+          await clearPending(sender_id);
+          await prisma.auditLog.create({
+            data: {
+              actor: 'user',
+              action: 'contact.deleted',
+              entity_type: 'Contact',
+              entity_id: contactId,
+              summary: `Contato ${contactName} removido`,
+            },
+          });
+          responseText = `✅ Contato ${contactName} removido.`;
+          break;
+        }
+
         await sendWhatsApp(comm.to!, comm.body!);
         await prisma.communication.update({
           where: { id: comm.id },
@@ -513,6 +572,9 @@ async function handleIncomingWhatsApp(
           responseText = `⚠️ Esta mensagem já foi processada.`;
           break;
         }
+
+        const cancelMeta = comm.metadata as Record<string, unknown>;
+
         await prisma.communication.update({
           where: { id: comm.id },
           data: { status: 'CANCELLED' },
@@ -521,13 +583,18 @@ async function handleIncomingWhatsApp(
         await prisma.auditLog.create({
           data: {
             actor: 'user',
-            action: 'whatsapp.cancelled',
+            action: cancelMeta?.kind === 'DELETE_CONTACT' ? 'contact.deletion_cancelled' : 'whatsapp.cancelled',
             entity_type: 'Communication',
             entity_id: comm.id,
-            summary: `WhatsApp cancelado para ${comm.to}`,
+            summary: cancelMeta?.kind === 'DELETE_CONTACT' ? `Deleção de contato cancelada` : `WhatsApp cancelado para ${comm.to}`,
           },
         });
-        responseText = `🚫 Mensagem cancelada.`;
+
+        if (cancelMeta?.kind === 'DELETE_CONTACT') {
+          responseText = `❌ Deleção cancelada.`;
+        } else {
+          responseText = `🚫 Mensagem cancelada.`;
+        }
         break;
       }
 

--- a/task.md
+++ b/task.md
@@ -439,3 +439,4 @@ pnpm lint && pnpm build
 | 2026-04-17 | Comandos [COWORK] concluído: Adicionado comando `/contatos` para listagem de contatos cadastrados — **235 testes passando** ✅ |
 | 2026-04-17 | Performance: Moved dayMap instantiation outside resolveDate in webhook.ts to reduce GC pressure. |
 | 2026-04-17 | Sentinel [COWORK] concluído: Automação de issues architecture-violation para o board PDLC (coluna 💡 Ideia) usando PROJECT_TOKEN. |
+| 2026-04-17 | [COWORK] concluído: Implementação de deleção de contatos via linguagem natural (intent DELETE_CONTACT) com confirmação obrigatória. |


### PR DESCRIPTION
This change allows users to delete contacts using natural language (e.g., "delete o contato Siqueira").

Key changes:
1.  **Intent Recognition**: Updated `llmService.ts` to classify "delete", "remove", or "apagar" requests as `DELETE_CONTACT` and extract the contact identifier.
2.  **Contact Service**: Added `deleteContact` method to `contactService.ts`.
3.  **Webhook Flow**:
    - When a `DELETE_CONTACT` intent is detected, Elvis looks for the contact by name or alias.
    - If found, it creates a draft communication and asks for confirmation (AC2).
    - If not found, it returns an error message (AC5).
    - Upon confirmation (1), the contact is deleted and a success message is sent (AC3).
    - Upon cancellation (2), Elvis confirms the cancellation (AC4).
4.  **Audit Logging**: Added audit log entries for contact deletion and deletion cancellation.
5.  **Testing**: Added unit tests in `llmService.test.ts` and `contactService.test.ts`. All tests pass.

Fixes #59

---
*PR created automatically by Jules for task [1633158225034916218](https://jules.google.com/task/1633158225034916218) started by @rafaeltcosta86*