### PR TITLE
refactor: rename pdlc: labels to upstream:

### DIFF
--- a/.github/workflows/jules-trigger.yml
+++ b/.github/workflows/jules-trigger.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - name: Adicionar label jules e comentar para acionar o agente
+      - name: Adicionar label jules, mover card e comentar para acionar o agente
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}
@@ -27,7 +27,23 @@ jobs:
               labels: ['jules'],
             });
 
-            // 2. Postar o comentário com as instruções detalhadas
+            // 2. Mover card para Desenvolvimento (remover upstream:aprovacao, adicionar upstream:desenvolvimento)
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                name: 'upstream:aprovacao',
+              });
+            } catch {}
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['upstream:desenvolvimento'],
+            });
+
+            // 3. Postar o comentário com as instruções detalhadas
             const body = [
               '@google-labs-jules A spec desta issue foi aprovada. Por favor, implemente conforme descrito no body acima.',
               '',
@@ -37,8 +53,7 @@ jobs:
               '3. Ler `docs/architecture.md` — invariantes de ouro e Definition of Done',
               '',
               '**Sequência obrigatória de labels no board:**',
-              `- Ao iniciar o desenvolvimento: \`gh issue edit ${issueNumber} --repo ${context.repo.owner}/${context.repo.repo} --remove-label "pdlc:aprovacao" --add-label "pdlc:desenvolvimento"\``,
-              `- Ao finalizar o desenvolvimento e ANTES de rodar os testes: \`gh issue edit ${issueNumber} --repo ${context.repo.owner}/${context.repo.repo} --remove-label "pdlc:desenvolvimento" --add-label "pdlc:testes"\``,
+              `- Ao finalizar o desenvolvimento e ANTES de rodar os testes: \`gh issue edit ${issueNumber} --repo ${context.repo.owner}/${context.repo.repo} --remove-label "upstream:desenvolvimento" --add-label "upstream:testes"\``,
               '- Ao abrir o PR: o workflow move o card para Code Review automaticamente',
               '',
               '**Regras de implementação:**',

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -55,9 +55,9 @@ jobs:
 
             console.log(`Issue #${context.payload.issue.number} movida para 💡 Ideia`);
 
-  move-card-on-pdlc-label:
-    name: Label pdlc:* → mover card upstream
-    if: github.event_name == 'issues' && startsWith(github.event.label.name, 'pdlc:')
+  move-card-on-upstream-label:
+    name: Label upstream:* → mover card
+    if: github.event_name == 'issues' && startsWith(github.event.label.name, 'upstream:')
     runs-on: ubuntu-latest
     steps:
       - name: Mapear label para coluna e mover card
@@ -67,12 +67,12 @@ jobs:
           script: |
             const label = context.payload.label.name;
             const statusMap = {
-              'pdlc:exploracao':      process.env.STATUS_EXPLORACAO,
-              'pdlc:brainstorming':   process.env.STATUS_BRAINSTORMING,
-              'pdlc:detalhando':      process.env.STATUS_DETALHANDO,
-              'pdlc:aprovacao':       process.env.STATUS_APROVACAO,
-              'pdlc:desenvolvimento': process.env.STATUS_DESENVOLVIMENTO,
-              'pdlc:testes':          process.env.STATUS_TESTES,
+              'upstream:exploracao':      process.env.STATUS_EXPLORACAO,
+              'upstream:brainstorming':   process.env.STATUS_BRAINSTORMING,
+              'upstream:detalhando':      process.env.STATUS_DETALHANDO,
+              'upstream:aprovacao':       process.env.STATUS_APROVACAO,
+              'upstream:desenvolvimento': process.env.STATUS_DESENVOLVIMENTO,
+              'upstream:testes':          process.env.STATUS_TESTES,
             };
             const optionId = statusMap[label];
             if (!optionId) { console.log(`Label ${label} sem mapeamento.`); return; }

--- a/.github/workflows/upstream-gate.yml
+++ b/.github/workflows/upstream-gate.yml
@@ -1,12 +1,9 @@
 name: Upstream PDLC Gate
 
 # Detecta aprovação do PM por comentário em issues no stage de Brainstorming.
-# Quando o PM comenta "aprovado", "approved", "ok" ou "pode detalhar":
-#   → troca pdlc:brainstorming por pdlc:detalhando
+# Quando o PM comenta "aprovado", "ok", seleciona uma opção ("Opção A", "Option B"), etc:
+#   → troca upstream:brainstorming por upstream:detalhando
 #   → o workflow project-automation.yml move o card automaticamente
-#
-# Nota: o agente upstream (Claude Code) ainda precisa ser invocado manualmente
-# para escrever os Acceptance Criteria após o card mover para Detalhar Solução.
 
 on:
   issue_comment:
@@ -15,10 +12,10 @@ on:
 jobs:
   brainstorm-gate:
     name: Comentário do PM → transição brainstorming → detalhando
-    # Só atua em issues (não PRs), com label pdlc:brainstorming, comentário não-bot
+    # Só atua em issues (não PRs), com label upstream:brainstorming, comentário não-bot
     if: |
       github.event.issue.pull_request == null &&
-      contains(github.event.issue.labels.*.name, 'pdlc:brainstorming') &&
+      contains(github.event.issue.labels.*.name, 'upstream:brainstorming') &&
       github.event.comment.user.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
@@ -30,7 +27,10 @@ jobs:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
             const body = context.payload.comment.body.toLowerCase().trim();
-            const approved = /\b(aprovado|approved|ok|lgtm|pode detalhar)\b/.test(body);
+
+            // Aprovação explícita ou seleção implícita de opção
+            const approved = /\b(aprovado|approved|ok|lgtm|pode detalhar)\b/.test(body)
+              || /\b(op[çc][aã]o|abordagem|option)\s+[abc]\b/.test(body);
 
             if (!approved) {
               console.log('Comentário não contém keyword de aprovação. Nenhuma ação.');
@@ -41,11 +41,11 @@ jobs:
             const issue_number = context.payload.issue.number;
 
             await github.rest.issues.removeLabel({
-              owner, repo, issue_number, name: 'pdlc:brainstorming'
+              owner, repo, issue_number, name: 'upstream:brainstorming'
             }).catch(() => {});
 
             await github.rest.issues.addLabels({
-              owner, repo, issue_number, labels: ['pdlc:detalhando']
+              owner, repo, issue_number, labels: ['upstream:detalhando']
             });
 
-            console.log(`Issue #${issue_number}: brainstorming aprovado pelo PM → pdlc:detalhando`);
+            console.log(`Issue #${issue_number}: brainstorming aprovado pelo PM → upstream:detalhando`);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,18 +40,18 @@ O agente upstream (Claude Code) sinaliza a progressão de um card adicionando um
 
 | Stage | Label | Quando adicionar |
 |---|---|---|
-| Exploração | `pdlc:exploracao` | Ao iniciar a análise de código/contexto |
-| Brainstorming | `pdlc:brainstorming` | Ao apresentar abordagens ao PM |
-| Detalhar Solução | `pdlc:detalhando` | Após aprovação do brainstorm (Gate 1) |
-| Aprovação | `pdlc:aprovacao` | Quando a spec está pronta para revisão |
+| Exploração | `upstream:exploracao` | Ao iniciar a análise de código/contexto |
+| Brainstorming | `upstream:brainstorming` | Ao apresentar abordagens ao PM |
+| Detalhar Solução | `upstream:detalhando` | Após aprovação do brainstorm (Gate 1) |
+| Aprovação | `upstream:aprovacao` | Quando a spec está pronta para revisão |
 
 ```bash
 # Exemplo — mover card da issue #35 para Exploração
-gh issue edit 35 --repo rafaeltcosta86/elvis --add-label "pdlc:exploracao"
+gh issue edit 35 --repo rafaeltcosta86/elvis --add-label "upstream:exploracao"
 ```
 
 O workflow `project-automation.yml` detecta a label e move o card no board automaticamente.
-Remova labels `pdlc:*` anteriores ao adicionar a nova (uma label por vez é suficiente).
+Remova labels `upstream:*` anteriores ao adicionar a nova (uma label por vez é suficiente).
 
 ## Workflow obrigatório para correção de violações
 


### PR DESCRIPTION
## Summary

- Rename all `pdlc:*` label references to `upstream:*` across workflows and documentation
- `project-automation.yml`: job renamed `move-card-on-upstream-label`, statusMap keys updated
- `upstream-gate.yml`: label swap changed from `pdlc:brainstorming → pdlc:detalhando` to `upstream:brainstorming → upstream:detalhando`
- `jules-trigger.yml`: label operations updated to `upstream:aprovacao → upstream:desenvolvimento`
- `AGENTS.md`: stage table and example commands updated

GitHub labels migrated:
- Created 6 new `upstream:*` labels with same colors as old `pdlc:*` labels
- Migrated active issues (#58, #62 → `upstream:desenvolvimento`; #60, #61 → `upstream:aprovacao`)
- Deleted old `pdlc:*` labels

## Test plan

- [ ] Verify board automation triggers correctly when `upstream:*` label is added to an issue
- [ ] Verify PM comment approval (`aprovado`, `ok`, `Opção A`) transitions `upstream:brainstorming → upstream:detalhando`
- [ ] Verify `spec:approved` label moves card to `upstream:desenvolvimento` and posts Jules comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)