### PR TITLE
fix(workflow): usar label jules sem prefixo stage: para acionar GitHub App

### DIFF
--- a/.github/workflows/jules-trigger.yml
+++ b/.github/workflows/jules-trigger.yml
@@ -12,19 +12,19 @@ jobs:
     permissions:
       issues: write
     steps:
-      - name: Adicionar label stage:jules e comentar para acionar o agente
+      - name: Adicionar label jules e comentar para acionar o agente
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
             const issueNumber = context.payload.issue.number;
 
-            // 1. Adicionar label stage:jules para garantir o gatilho externo
+            // 1. Adicionar label jules para acionar o GitHub App do Jules
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
-              labels: ['stage:jules'],
+              labels: ['jules'],
             });
 
             // 2. Mover card para Desenvolvimento


### PR DESCRIPTION
O GitHub App do Google Labs Jules reage ao label `jules` (sem prefixo), não `stage:jules`. O PR #69 renomeou erroneamente para `stage:jules`, o que impedia o agente de ser acionado.

## Causa raiz

A convenção `stage:` é para estágios do board PDLC. `jules` é um label de integração com um GitHub App externo — exceção à convenção.

## Fix

`jules-trigger.yml`: `labels: ['stage:jules']` → `labels: ['jules']`

Confirmado empiricamente: Jules só começou a trabalhar na issue #68 após adicionar o label `jules` sem prefixo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)