### PR TITLE
Improve Whisper transcription accuracy with prompt parameter

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -72,3 +72,6 @@ WHATSAPP_CONTACTS=
 # Free tier: https://console.groq.com — sem custo para os cenários esperados
 # Usado apenas quando o regex do commandParser não reconhece a mensagem
 GROQ_API_KEY=
+
+# Lista de termos para guiar a transcrição do Whisper (nomes próprios, siglas, etc)
+WHISPER_PROMPT="Claude Code, Anthropic, Elvis, Rafael"

--- a/apps/api/src/lib/__tests__/whisperService.test.ts
+++ b/apps/api/src/lib/__tests__/whisperService.test.ts
@@ -74,7 +74,7 @@ describe('transcribeAudio', () => {
     (mockedAxios.post as any).mockResolvedValueOnce({ data: { text: 'ok' } });
     await transcribeAudio(Buffer.from('audio'), 'audio/ogg');
 
-    const formData = mockedAxios.post.mock.calls[0][1] as any;
+    const formData = (mockedAxios.post as any).mock.calls[0][1] as any;
     // FormData do pacote 'form-data' usa internal _streams
     const promptPart = formData._streams.find((s: any) => typeof s === 'string' && s.includes('name="prompt"'));
     expect(promptPart).toBeDefined();
@@ -88,7 +88,7 @@ describe('transcribeAudio', () => {
     (mockedAxios.post as any).mockResolvedValueOnce({ data: { text: 'ok' } });
     await transcribeAudio(Buffer.from('audio'), 'audio/ogg');
 
-    const formData = mockedAxios.post.mock.calls[0][1] as any;
+    const formData = (mockedAxios.post as any).mock.calls[0][1] as any;
     const promptValue = formData._streams[formData._streams.findIndex((s: any) => typeof s === 'string' && s.includes('name="prompt"')) + 1];
     expect(promptValue).toBe('Custom Prompt, Test');
 

--- a/apps/api/src/lib/__tests__/whisperService.test.ts
+++ b/apps/api/src/lib/__tests__/whisperService.test.ts
@@ -69,4 +69,29 @@ describe('transcribeAudio', () => {
       })
     );
   });
+
+  it('passa parâmetro prompt no FormData', async () => {
+    (mockedAxios.post as any).mockResolvedValueOnce({ data: { text: 'ok' } });
+    await transcribeAudio(Buffer.from('audio'), 'audio/ogg');
+
+    const formData = mockedAxios.post.mock.calls[0][1] as any;
+    // FormData do pacote 'form-data' usa internal _streams
+    const promptPart = formData._streams.find((s: any) => typeof s === 'string' && s.includes('name="prompt"'));
+    expect(promptPart).toBeDefined();
+
+    const promptValue = formData._streams[formData._streams.indexOf(promptPart) + 1];
+    expect(promptValue).toBe('Claude Code, Anthropic, Elvis, Rafael');
+  });
+
+  it('usa WHISPER_PROMPT da variável de ambiente se presente', async () => {
+    process.env.WHISPER_PROMPT = 'Custom Prompt, Test';
+    (mockedAxios.post as any).mockResolvedValueOnce({ data: { text: 'ok' } });
+    await transcribeAudio(Buffer.from('audio'), 'audio/ogg');
+
+    const formData = mockedAxios.post.mock.calls[0][1] as any;
+    const promptValue = formData._streams[formData._streams.findIndex((s: any) => typeof s === 'string' && s.includes('name="prompt"')) + 1];
+    expect(promptValue).toBe('Custom Prompt, Test');
+
+    delete process.env.WHISPER_PROMPT;
+  });
 });

--- a/apps/api/src/lib/whisperService.ts
+++ b/apps/api/src/lib/whisperService.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import FormData from 'form-data';
 
 const GROQ_API_URL = 'https://api.groq.com/openai/v1/audio/transcriptions';
+const DEFAULT_WHISPER_PROMPT = 'Claude Code, Anthropic, Elvis, Rafael';
 
 export async function transcribeAudio(buffer: Buffer, mimetype: string): Promise<string> {
   const apiKey = process.env.GROQ_API_KEY;
@@ -21,6 +22,7 @@ export async function transcribeAudio(buffer: Buffer, mimetype: string): Promise
     form.append('model', 'whisper-large-v3-turbo');
     form.append('language', 'pt');
     form.append('response_format', 'json');
+    form.append('prompt', process.env.WHISPER_PROMPT || DEFAULT_WHISPER_PROMPT);
 
     const response = await axios.post(GROQ_API_URL, form, {
       headers: {

--- a/task.md
+++ b/task.md
@@ -344,8 +344,9 @@ curl -X POST /webhook/nanoclaw -d '{"message":"/li oi"}'
 
 > Custo estimado: $0 no free tier do Groq (Whisper Large v3) para até 100 msg/dia com 50% voz.
 
-- [ ] Receber payload de áudio OGG do webhook NanoClaw/Baileys
-- [ ] Transcrever via Groq Whisper (`whisper-large-v3`, free tier)
+- [x] Receber payload de áudio OGG do webhook NanoClaw/Baileys
+- [x] Transcrever via Groq Whisper (`whisper-large-v3`, free tier)
+- [x] Corrigir transcrição de nomes próprios via parâmetro `prompt` (ex: "Claude Code", "Anthropic")
 - [ ] Passar transcrição ao `handleIncomingWhatsApp` como texto normal
 - [ ] Testar com mensagens de voz reais no WhatsApp
 
@@ -442,3 +443,4 @@ pnpm lint && pnpm build
 | 2026-04-17 | Comandos [COWORK] concluído: Edição de contatos via linguagem natural (EDIT_CONTACT) integrada ao webhook — **243 testes passando** ✅ |
 | 2026-04-24 | Testing [COWORK] concluído: Adicionados testes unitários para MockAdapter em packages/shared. |
 | 2026-04-25 | Feat [COWORK] concluído: Elvis se apresenta para um contato (INTRODUCE_SELF) com contexto opcional e geração via LLM — **306 testes passando** ✅ |
+| 2026-04-25 | Fix [COWORK] concluído: Adicionado parâmetro `prompt` no Whisper para melhorar transcrição de nomes próprios. |


### PR DESCRIPTION
This change addresses the issue where proper names like "Claude Code" and "Anthropic" were being mistranscribed by the Whisper API. By adding the `prompt` parameter to the Groq Whisper transcription call, we can guide the model with these specific terms.

Key changes:
- `apps/api/src/lib/whisperService.ts`: Added `prompt` parameter logic using `WHISPER_PROMPT` env or a default constant.
- `apps/api/src/lib/__tests__/whisperService.test.ts`: Added tests to ensure the parameter is correctly passed and respects environment variables.
- `.env.prod.example`: Added `WHISPER_PROMPT` for production configuration.
- `task.md`: Updated to reflect the progress on audio support.

Fixes #77

---
*PR created automatically by Jules for task [8205077060445068657](https://jules.google.com/task/8205077060445068657) started by @rafaeltcosta86*