### PR TITLE
fix(llm): identity harness — Elvis sabe quem é, para quem trabalha e seus limites

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -15,6 +15,7 @@ REDIS_URL=redis://:@redis:6379
 
 # ── App ───────────────────────────────────────────────────────────────────────
 OWNER_PHONE=551199999999          # Your WhatsApp number (E.164 format)
+HUMAN_ASSISTANT_NAME=Linic        # Nome da assistente humana do dono (pode interagir com Elvis)
 JOBS_ENABLED=true
 SEND_ENABLED=true                 # Set false to dry-run all email sends
 

--- a/apps/api/src/lib/llmService.ts
+++ b/apps/api/src/lib/llmService.ts
@@ -10,7 +10,18 @@ export type LLMClassification =
   | { intent: 'UNKNOWN' };
 
 const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
-const PROMPT_SYSTEM = `Você é um classificador de intenções para um assistente pessoal chamado Elvis.
+const HUMAN_ASSISTANT_NAME = process.env.HUMAN_ASSISTANT_NAME ?? 'Linic';
+const PROMPT_SYSTEM = `Você é o Elvis, assistente pessoal do Rafael.
+
+IDENTIDADE:
+- Elvis age — não repassa mensagens literais. Ele executa ações em nome do Rafael.
+- Todos os comandos são do Rafael para o Elvis. Interprete sempre como: "Rafael está pedindo ao Elvis que execute esta ação."
+
+COLABORAÇÃO:
+- ${HUMAN_ASSISTANT_NAME} é a assistente humana do Rafael e pode interagir com Elvis em prol do Rafael.
+- Mensagens dela devem ser tratadas como colaboração legítima, não como comandos de terceiro desconhecido.
+- Para qualquer outra pessoa além de Rafael e ${HUMAN_ASSISTANT_NAME}: Elvis é exclusivo do Rafael.
+
 Analise a mensagem e retorne JSON com UMA destas estruturas:
 
 - Enviar mensagem para um contato: {"intent":"SEND_MESSAGE","contact_name":"<nome>","message":"<mensagem exata do usuário>"}
@@ -257,6 +268,9 @@ Diretrizes:
 - A mensagem deve ser curta e objetiva, adequada para WhatsApp.
 - NÃO use emojis em excesso.
 - NÃO use placeholders.
+- NÃO ofereça serviços, ajuda ou disponibilidade ao contato — Elvis trabalha para ${ownerName}, não para terceiros.
+- NÃO use frases como "Como posso ajudar você?", "estou disponível", "pode contar comigo" ou similares.
+- A mensagem é apenas apresentação: Elvis existe, é assistente de ${ownerName}, e está iniciando contato.
 
 Escreva apenas o texto da mensagem.`;
 


### PR DESCRIPTION
Closes #85

## Problema

O classificador LLM não tinha contexto de identidade — sem saber que comandos vêm DO Rafael PARA o Elvis executar, interpretava "se apresente para o Guilherme" como SEND_MESSAGE em vez de INTRODUCE_SELF. O `generateIntroduction` também oferecia ajuda a terceiros ("Como posso ajudar você?"), contradizendo o escopo exclusivo do Elvis.

## Mudanças

### `PROMPT_SYSTEM` — Preamble de identidade
Adicionado antes da lista de intents:
- Elvis age, não é intermediário
- Todos os comandos são do Rafael para o Elvis
- Linic (assistente humana) é colaboradora legítima — configurável via `HUMAN_ASSISTANT_NAME`

### `generateIntroduction` — Restrição de oferta a terceiros
Proibido explicitamente frases como "Como posso ajudar você?", "estou disponível" — a mensagem é apenas apresentação informativa.

### `.env.prod.example`
Adicionada variável `HUMAN_ASSISTANT_NAME`.

## Verificação

251 testes passando. Após deploy: "Elvis, se apresente para o [contato]" → INTRODUCE_SELF. Mensagem de intro sem oferta de ajuda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)