### PR TITLE
fix: remover frases proibidas e tornar identidade IA explícita nas apresentações

### DIFF
--- a/apps/api/src/lib/llmService.ts
+++ b/apps/api/src/lib/llmService.ts
@@ -265,17 +265,18 @@ export async function generateIntroduction(
   if (!apiKey) return `Olá ${contactName}, eu sou o Elvis, assistente do ${ownerAlias ?? 'Rafael'}.`;
 
   const ownerName = ownerAlias ?? process.env.OWNER_NAME ?? 'Rafael';
-  const systemPrompt = `Você é o Elvis, assistente pessoal do ${ownerName}.
+  const systemPrompt = `Você é o Elvis, um assistente de IA pessoal do ${ownerName}.
 Escreva uma mensagem curta de apresentação para ${contactName} no WhatsApp.
 ${context ? `Contexto da relação: ${context}.` : ''}
 
-Tom: direto e descontraído — como um assistente real falaria, não como um e-mail corporativo.
-EVITE: "estabelecer uma conexão", "comunicação direta", "É um prazer conhecer você", "estou à disposição", frases de LinkedIn.
-PREFIRA: frases simples e naturais, como "Trabalho com o ${ownerName}" ou "Fico por aqui se precisarem de algo".
+Tom: direto e descontraído, como uma mensagem de WhatsApp — não um e-mail corporativo.
+Exemplos de estilo:
+  Sem contexto: "Oi ${contactName}, sou o Elvis, assistente de IA do ${ownerName}. Ele pediu que eu me apresentasse."
+  Com contexto (ex: trabalharam juntos): "Oi ${contactName}, sou o Elvis, assistente de IA do ${ownerName} — vocês se conhecem da McKinsey. Ele queria que eu entrasse em contato."
 
 Regras:
-- Identifique-se como Elvis, assistente do ${ownerName}.
-- Se houver contexto, use-o para personalizar (ex: mencionar onde se conheceram).
+- Deixe claro que é um assistente de IA — não esconda isso.
+- Se houver contexto, use-o para personalizar.
 - Mensagem curta — 2 a 3 frases no máximo.
 - Sem emojis.
 - NÃO ofereça ajuda ao contato — Elvis trabalha para ${ownerName}, não para terceiros.

--- a/apps/api/src/lib/llmService.ts
+++ b/apps/api/src/lib/llmService.ts
@@ -265,20 +265,21 @@ export async function generateIntroduction(
   if (!apiKey) return `Olá ${contactName}, eu sou o Elvis, assistente do ${ownerAlias ?? 'Rafael'}.`;
 
   const ownerName = ownerAlias ?? process.env.OWNER_NAME ?? 'Rafael';
-  const systemPrompt = `Você é o Elvis, um assistente pessoal inteligente e natural do ${ownerName}.
-Sua tarefa é escrever uma mensagem de apresentação para um novo contato chamado ${contactName}.
-${context ? `O contexto da relação é: ${context}.` : ''}
+  const systemPrompt = `Você é o Elvis, assistente pessoal do ${ownerName}.
+Escreva uma mensagem curta de apresentação para ${contactName} no WhatsApp.
+${context ? `Contexto da relação: ${context}.` : ''}
 
-Diretrizes:
-- Seja educado, profissional mas com um toque de naturalidade.
+Tom: direto e descontraído — como um assistente real falaria, não como um e-mail corporativo.
+EVITE: "estabelecer uma conexão", "comunicação direta", "É um prazer conhecer você", "estou à disposição", frases de LinkedIn.
+PREFIRA: frases simples e naturais, como "Trabalho com o ${ownerName}" ou "Fico por aqui se precisarem de algo".
+
+Regras:
 - Identifique-se como Elvis, assistente do ${ownerName}.
-- Se houver contexto, incorpore-o naturalmente na mensagem para que o contato saiba de quem você está falando.
-- A mensagem deve ser curta e objetiva, adequada para WhatsApp.
-- NÃO use emojis em excesso.
+- Se houver contexto, use-o para personalizar (ex: mencionar onde se conheceram).
+- Mensagem curta — 2 a 3 frases no máximo.
+- Sem emojis.
+- NÃO ofereça ajuda ao contato — Elvis trabalha para ${ownerName}, não para terceiros.
 - NÃO use placeholders.
-- NÃO ofereça serviços, ajuda ou disponibilidade ao contato — Elvis trabalha para ${ownerName}, não para terceiros.
-- NÃO use frases como "Como posso ajudar você?", "estou disponível", "pode contar comigo" ou similares.
-- A mensagem é apenas apresentação: Elvis existe, é assistente de ${ownerName}, e está iniciando contato.
 
 Escreva apenas o texto da mensagem.`;
 


### PR DESCRIPTION
## Summary

- Remove lista de frases proibidas do system prompt de `generateIntroduction` — tom + exemplos são suficientes
- Elvis agora se identifica explicitamente como assistente de IA, sem esconder isso

Closes #89