### PR TITLE
fix(ci): corrigir QA Agent no path de sucesso

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -155,7 +155,82 @@ jobs:
                   owner: repoOwner, repo: repoName, issue_number: issueNumber
                 });
                 await moveItem(issue.node_id);
-                console.log(`Issue #${issueNumber} movida para Code Review`);
+                console.log(`Issue #${issueNumber} movida para 🧪 Testes`);
+              } catch (e) {
+                console.log(`Aviso: não foi possível mover issue #${issueNumber}: ${e.message}`);
+              }
+            }
+
+  move-card-on-qa-pass:
+    name: QA passou → 👁 Code Review
+    if: >
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.name == 'QA Agent' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mover issue para 👁 Code Review e adicionar stage:revisao
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            let prNumber = context.payload.workflow_run.pull_requests?.[0]?.number;
+            if (!prNumber) {
+              const sha = context.payload.workflow_run.head_sha;
+              const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner, repo: context.repo.repo, commit_sha: sha
+              });
+              prNumber = prs.data[0]?.number;
+            }
+            if (!prNumber) { console.log('Sem PR associado.'); return; }
+            const repoOwner = context.repo.owner;
+            const repoName = context.repo.repo;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: repoOwner, repo: repoName, pull_number: prNumber
+            });
+
+            const body = pr.body ?? '';
+            const linkedIssues = [...body.matchAll(/(?:Closes?|Fixes?|Resolves?)\s+#(\d+)/gi)]
+              .map(m => parseInt(m[1]));
+
+            const moveItem = async (nodeId) => {
+              const addResult = await github.graphql(`
+                mutation($projectId: ID!, $contentId: ID!) {
+                  addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                    item { id }
+                  }
+                }
+              `, { projectId: process.env.PROJECT_ID, contentId: nodeId });
+
+              const itemId = addResult.addProjectV2ItemById.item.id;
+
+              await github.graphql(`
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: ProjectV2FieldValue!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: $value
+                  }) { projectV2Item { id } }
+                }
+              `, {
+                projectId: process.env.PROJECT_ID,
+                itemId,
+                fieldId: process.env.STATUS_FIELD_ID,
+                value: { singleSelectOptionId: process.env.STATUS_CODE_REVIEW }
+              });
+            };
+
+            if (linkedIssues.length === 0) {
+              await moveItem(pr.node_id).catch(() => {});
+              console.log(`PR #${prNumber} movido para 👁 Code Review após QA passar`);
+            }
+
+            for (const issueNumber of linkedIssues) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: repoOwner, repo: repoName, issue_number: issueNumber
+                });
+                await moveItem(issue.node_id);
+                console.log(`Issue #${issueNumber} movida para 👁 Code Review após QA passar`);
               } catch (e) {
                 console.log(`Aviso: não foi possível mover issue #${issueNumber}: ${e.message}`);
               }

--- a/.github/workflows/qa-agent.yml
+++ b/.github/workflows/qa-agent.yml
@@ -1,0 +1,151 @@
+name: QA Agent
+
+on:
+  workflow_run:
+    workflows: ["Elvis Sentinel"]
+    types: [completed]
+
+jobs:
+  qa-review:
+    name: QA — Verificar cobertura de ACs
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+
+    steps:
+      - name: Criar labels QA se não existirem
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          gh label create "qa:needs-work" \
+            --color "E11D48" \
+            --description "QA Agent: ACs sem cobertura" \
+            --repo ${{ github.repository }} \
+            --force
+          gh label create "qa:approved" \
+            --color "16A34A" \
+            --description "QA Agent: todos os ACs cobertos" \
+            --repo ${{ github.repository }} \
+            --force
+
+      - name: Extrair PR e issue linkada
+        id: context
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          SHA="${{ github.event.workflow_run.head_sha }}"
+
+          PR_NUMBER=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0].number // empty' 2>/dev/null)
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Sem PR associado ao workflow_run. Pulando."
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body')
+          ISSUE_NUMBER=$(echo "$PR_BODY" | grep -oP '(?:Closes?|Fixes?|Resolves?)\s+#\K\d+' | head -1)
+
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo "Nenhuma issue linkada encontrada no PR. Pulando QA."
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "issue_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+          echo "repo=$REPO" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+
+      - name: Checkout do código do PR
+        if: steps.context.outputs.skip == 'false'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Setup pnpm
+        if: steps.context.outputs.skip == 'false'
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Instalar dependências
+        if: steps.context.outputs.skip == 'false'
+        run: pnpm install --frozen-lockfile
+
+      - name: Rodar testes e verificar ACs com Gemini
+        if: steps.context.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+          ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
+          REPO: ${{ steps.context.outputs.repo }}
+          CI: "true"
+        run: |
+          echo "Verificando ACs da issue #${ISSUE_NUMBER} para o PR #${PR_NUMBER}..."
+
+          ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json body --jq '.body')
+
+          # Rodar testes com reporter verbose para capturar nomes descritivos
+          TEST_OUTPUT=$(pnpm --filter api exec vitest run --reporter=verbose 2>&1 || true)
+          echo "--- Output dos testes ---"
+          echo "$TEST_OUTPUT" | tail -50
+          echo "-------------------------"
+
+          PROMPT="Você é um QA Engineer. Sua tarefa: verificar se cada Acceptance Criteria da issue está coberto por um teste que passou.
+
+          ## Issue #${ISSUE_NUMBER} — Acceptance Criteria:
+          ${ISSUE_BODY}
+
+          ## Output dos testes (vitest --reporter=verbose):
+          ${TEST_OUTPUT}
+
+          Para cada AC (linhas que começam com \"- [ ]\" ou \"- [x]\"), identifique:
+          1. Há um teste que passou e que cobre este comportamento?
+          2. O nome/descrição do teste confirma a cobertura?
+
+          Responda SOMENTE em JSON válido sem markdown:
+          {\"result\":\"approved\"|\"needs-work\",\"acs\":[{\"text\":\"...\",\"covered\":true|false,\"reason\":\"nome do teste ou motivo da ausência\"}],\"summary\":\"...\"}"
+
+          RESPONSE=$(curl -s \
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${GEMINI_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg prompt "$PROMPT" '{contents:[{parts:[{text:$prompt}]}]}')")
+
+          RESULT=$(echo "$RESPONSE" | jq -r '.candidates[0].content.parts[0].text // empty')
+
+          if [ -z "$RESULT" ]; then
+            echo "Erro ao chamar Gemini API. Resposta: $RESPONSE"
+            RESULT='{"result":"needs-work","acs":[],"summary":"Erro ao chamar Gemini API — verifique o secret GEMINI_API_KEY."}'
+          fi
+
+          QA_RESULT=$(echo "$RESULT" | jq -r '.result // "needs-work"')
+
+          if [ "$QA_RESULT" = "approved" ]; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "qa:approved" 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "qa:needs-work" 2>/dev/null || true
+            echo "QA aprovado. Todos os ACs cobertos por testes reais."
+            exit 0
+          else
+            HEADER="❌ **QA Agent — Necessita correção** — ACs sem cobertura"
+            COMMENT=$(echo "$RESULT" | jq -r --arg h "$HEADER" --arg issue "$ISSUE_NUMBER" '
+              $h + "\n\n" +
+              (.acs | map(
+                (if .covered then "- ✅ " else "- ❌ " end) + .text + "\n  > " + .reason
+              ) | join("\n")) +
+              "\n\n**Resumo:** " + .summary +
+              "\n\n---\n*QA Agent — verificação automática de ACs. Issue: #" + $issue + "*"
+            ' 2>/dev/null || printf '%s\n\n**Resumo:** Erro ao formatar relatório.\n' "$HEADER")
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT"
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "qa:needs-work" 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "qa:approved" 2>/dev/null || true
+            echo "QA reprovado. ACs sem cobertura identificados."
+            exit 1
+          fi


### PR DESCRIPTION
## Problema

Quando o Jules abria uma PR e os testes passavam, nenhuma ação ocorria: sem comentário na PR, sem label, card preso em 🧪 Testes.

## Causa raiz

**Bug 1 — condição inválida em `move-card-on-qa-pass`**
```yaml
github.event.workflow_run.event == 'pull_request'  # sempre falso
```
O QA Agent é triggerado por `workflow_run` (não `pull_request`), então essa condição nunca era verdadeira e o card nunca saía de Testes.

**Bug 2 — `pull_requests[0]` não confiável em `workflow_run`**
O array `pull_requests` do contexto `workflow_run` pode estar vazio, causando early-exit silencioso do QA Agent sem postar nada.

## Correções

- Remove a condição de evento inválida de `move-card-on-qa-pass`
- Substitui `pull_requests[0].number` por lookup via head SHA na API (`/commits/$SHA/pulls`) em ambos os workflows
- Path de sucesso: apenas label `qa:approved` (sem comentário)
- Path de falha: mantém comentário + `qa:needs-work`, remove `qa:approved` se existia

## Teste

Após merge, re-triggerar PR #96 (issue #60) com commit vazio na branch.