### PR TITLE
Refactor parseCommand to deterministic scope and centralize LLM intent detection

### DIFF
--- a/apps/api/src/lib/__tests__/commandParser.test.ts
+++ b/apps/api/src/lib/__tests__/commandParser.test.ts
@@ -137,7 +137,7 @@ describe('parseCommand', () => {
     });
   });
 
-  describe('UNKNOWN', () => {
+  describe('UNKNOWN (natural language fallback)', () => {
     it('returns UNKNOWN intent with rawText for plain text', () => {
       expect(parseCommand('comprar leite')).toEqual({
         intent: 'UNKNOWN',

--- a/apps/api/src/lib/__tests__/commandParser.test.ts
+++ b/apps/api/src/lib/__tests__/commandParser.test.ts
@@ -137,80 +137,35 @@ describe('parseCommand', () => {
     });
   });
 
-  describe('SEND_TO', () => {
-    it('estrutura clássica: manda para <nome>: <msg>', () => {
-      expect(parseCommand('manda para amanda: oi')).toEqual({
-        intent: 'SEND_TO',
-        args: { contactName: 'amanda', message: 'oi' },
-      });
-    });
-
-    it('linguagem natural de áudio: manda <msg> pra <nome>', () => {
-      expect(parseCommand('Manda um oi pra Amanda.')).toEqual({
-        intent: 'SEND_TO',
-        args: { contactName: 'Amanda', message: 'um oi' },
-      });
-    });
-
-    it('linguagem natural: manda um abraço para João', () => {
-      expect(parseCommand('manda um abraço para João')).toEqual({
-        intent: 'SEND_TO',
-        args: { contactName: 'João', message: 'um abraço' },
-      });
-    });
-
-  });
-
-  describe('CREATE_TASK', () => {
-    it('returns CREATE_TASK intent with rawText for plain text', () => {
+  describe('UNKNOWN', () => {
+    it('returns UNKNOWN intent with rawText for plain text', () => {
       expect(parseCommand('comprar leite')).toEqual({
-        intent: 'CREATE_TASK',
+        intent: 'UNKNOWN',
         args: { rawText: 'comprar leite' },
       });
     });
 
     it('trims whitespace from rawText', () => {
       expect(parseCommand('  comprar leite  ')).toEqual({
-        intent: 'CREATE_TASK',
+        intent: 'UNKNOWN',
         args: { rawText: 'comprar leite' },
       });
     });
 
-    it('returns CREATE_TASK with empty rawText for empty string', () => {
+    it('returns UNKNOWN with empty rawText for empty string', () => {
       expect(parseCommand('')).toEqual({
-        intent: 'CREATE_TASK',
+        intent: 'UNKNOWN',
         args: { rawText: '' },
       });
     });
-  });
 
-  describe('CREATE_EVENT', () => {
-    it('detects "marca" prefix', () => {
-      expect(parseCommand('marca uma reunião com a Linic quinta às 15h')).toEqual({
-        intent: 'CREATE_EVENT',
-        args: { rawText: 'marca uma reunião com a Linic quinta às 15h' },
-      });
+    it('returns UNKNOWN for previous SEND_TO patterns', () => {
+      expect(parseCommand('manda para amanda: oi').intent).toBe('UNKNOWN');
+      expect(parseCommand('Manda um oi pra Amanda.').intent).toBe('UNKNOWN');
     });
 
-    it('detects "agenda" prefix', () => {
-      expect(parseCommand('agenda call com João amanhã às 10h')).toEqual({
-        intent: 'CREATE_EVENT',
-        args: { rawText: 'agenda call com João amanhã às 10h' },
-      });
-    });
-
-    it('detects "criar reunião" prefix', () => {
-      expect(parseCommand('criar uma reunião de time sexta')).toEqual({
-        intent: 'CREATE_EVENT',
-        args: { rawText: 'criar uma reunião de time sexta' },
-      });
-    });
-
-    it('detects "marcar" (with r)', () => {
-      expect(parseCommand('marcar dentista amanhã 9h')).toEqual({
-        intent: 'CREATE_EVENT',
-        args: { rawText: 'marcar dentista amanhã 9h' },
-      });
+    it('returns UNKNOWN for previous CREATE_EVENT patterns', () => {
+      expect(parseCommand('marca reunião').intent).toBe('UNKNOWN');
     });
   });
 });

--- a/apps/api/src/lib/commandParser.ts
+++ b/apps/api/src/lib/commandParser.ts
@@ -1,5 +1,4 @@
 export type Intent =
-  | 'CREATE_TASK'
   | 'TODAY'
   | 'DONE'
   | 'POSTPONE'
@@ -11,7 +10,6 @@ export type Intent =
   | 'CONFIRM'
   | 'CANCEL'
   | 'ALIAS_SHORTCUT'
-  | 'CREATE_EVENT'
   | 'LIST_CONTACTS'
   | 'LIST_TASKS'
   | 'DELETE_CONTACT'

--- a/apps/api/src/lib/commandParser.ts
+++ b/apps/api/src/lib/commandParser.ts
@@ -8,7 +8,6 @@ export type Intent =
   | 'MORE_PROACTIVE'
   | 'LESS_PROACTIVE'
   | 'RESET_PREFS'
-  | 'SEND_TO'
   | 'CONFIRM'
   | 'CANCEL'
   | 'ALIAS_SHORTCUT'
@@ -156,42 +155,6 @@ export function parseCommand(text: string): ParsedCommand {
     };
   }
 
-  // Linguagem natural: "marca/agenda/cria reunião/evento/call..."
-  const createEventMatch = /^(?:marca(?:r)?|agenda(?:r)?|cria(?:r)?\s+(?:uma?\s+)?(?:reunião|evento|call|compromisso|meet))\b/i.test(trimmed);
-  if (createEventMatch) {
-    return {
-      intent: 'CREATE_EVENT',
-      args: { rawText: trimmed },
-    };
-  }
-
-  // Linguagem natural de áudio: "manda <msg> pra/para/pro <nome>[.]"
-  // ex: "Manda um oi pra Amanda." / "manda um abraço para João"
-  const sendToNaturalMatch = /^(?:manda(?:r)?|pergunta(?:r)?|fala(?:r)?|diz(?:er)?|avisa(?:r)?)\s+(.+?)\s+(?:pra|para|pro)\s+([^\s,.:]+)[.,]?$/i.exec(trimmed);
-  if (sendToNaturalMatch) {
-    return {
-      intent: 'SEND_TO',
-      args: {
-        contactName: sendToNaturalMatch[2].trim(),
-        message: sendToNaturalMatch[1].trim(),
-      },
-    };
-  }
-
-  // manda para <nome>: <msg> | fala com <nome> que <msg> | avisa <nome>: <msg>
-  const sendToMatch = /^(?:manda(?:r)?\s+(?:(?:uma?\s+)?mensagem\s+)?(?:para|pro|pra)|fala(?:r)?\s+(?:com|pra)|pergunta(?:r)?\s+(?:para|pro|pra)|avisa(?:r)?|diz(?:er)?\s+(?:para|pro|pra))\s+(?:o\s|a\s|os\s|as\s)?(.+?)(?::|,|\s+(que|dizendo|se|perguntando)\s+)\s*(.+)$/i.exec(trimmed);
-  if (sendToMatch) {
-    const connector = sendToMatch[2];
-    const message = sendToMatch[3].trim();
-    return {
-      intent: 'SEND_TO',
-      args: {
-        contactName: sendToMatch[1].trim(),
-        message: connector && ![':', ','].includes(connector) ? `${connector} ${message}` : message,
-      },
-    };
-  }
-
   // /alias <mensagem> — atalho de contato (ex: /linic olá)
   const aliasMatch = /^(\/\S+)\s+(.+)$/i.exec(trimmed);
   if (aliasMatch) {
@@ -201,9 +164,9 @@ export function parseCommand(text: string): ParsedCommand {
     };
   }
 
-  // Anything else is CREATE_TASK
+  // Anything else is UNKNOWN
   return {
-    intent: 'CREATE_TASK',
+    intent: 'UNKNOWN',
     args: { rawText: trimmed },
   };
 }

--- a/apps/api/src/routes/__tests__/webhook.audio.test.ts
+++ b/apps/api/src/routes/__tests__/webhook.audio.test.ts
@@ -108,9 +108,15 @@ describe('POST /webhook/baileys-audio', () => {
     expect(sentText).toContain('✅ Tarefa criada: "lembra de ligar pra Linic amanhã"');
   });
 
-  it('áudio próprio (is_forwarded=false): SEND_TO cria draft e mostra preview com confirm/cancel', async () => {
+  it('áudio próprio (is_forwarded=false): SEND_MESSAGE cria draft e mostra preview com confirm/cancel', async () => {
     process.env.WHATSAPP_CONTACTS = 'amanda:5541999990001';
-    vi.mocked(transcribeAudio).mockResolvedValueOnce('manda para amanda: oi');
+    vi.mocked(transcribeAudio).mockResolvedValueOnce('manda um oi para amanda');
+    // normalizeAudioCommand is mocked to return input text by default in this file
+    vi.mocked(classifyIntent).mockResolvedValueOnce({
+      intent: 'SEND_MESSAGE',
+      contact_name: 'amanda',
+      message: 'oi'
+    });
     (prisma.communication.create as any).mockResolvedValueOnce({ id: 'comm-audio-001', status: 'AWAITING_APPROVAL' });
     (prisma.auditLog.create as any).mockResolvedValueOnce({});
 
@@ -126,7 +132,8 @@ describe('POST /webhook/baileys-audio', () => {
       })
     );
     const sentText: string = vi.mocked(sendWhatsApp).mock.calls[0][1];
-    expect(sentText).toContain('manda para amanda: oi');
+    expect(sentText).toContain('amanda');
+    expect(sentText).toContain('oi');
     expect(sentText).toContain('1️⃣');
   });
 

--- a/apps/api/src/routes/__tests__/webhook.test.ts
+++ b/apps/api/src/routes/__tests__/webhook.test.ts
@@ -228,7 +228,7 @@ describe('Webhook — ALIAS_SHORTCUT', () => {
     expect(sentText).toContain('1️⃣');
   });
 
-  it('falls through to CREATE_TASK when alias is not found', async () => {
+  it('falls through to task creation when alias is not found', async () => {
     (findByAlias as any).mockResolvedValue(null);
     (classifyIntent as any).mockResolvedValue({ intent: 'UNKNOWN' });
     (prisma.task.create as any).mockResolvedValue({ id: 'task-1', title: '/xpto oi' });

--- a/apps/api/src/routes/__tests__/webhook.test.ts
+++ b/apps/api/src/routes/__tests__/webhook.test.ts
@@ -324,7 +324,7 @@ describe('Webhook — REGISTER_ALIAS (LLM semântico)', () => {
   });
 });
 
-describe('Webhook — SEND_TO (approval gate)', () => {
+describe('Webhook — SEND_MESSAGE (via LLM UNKNOWN path)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.WEBHOOK_SECRET = WEBHOOK_SECRET;
@@ -337,8 +337,14 @@ describe('Webhook — SEND_TO (approval gate)', () => {
     (prisma.auditLog.create as any).mockResolvedValue({});
   });
 
-  it('does NOT send WhatsApp immediately when SEND_TO is triggered', async () => {
-    await webhookPost('manda para assistente: olá tudo bem');
+  it('does NOT send WhatsApp immediately when SEND_MESSAGE is triggered', async () => {
+    (classifyIntent as any).mockResolvedValue({
+      intent: 'SEND_MESSAGE',
+      contact_name: 'assistente',
+      message: 'olá tudo bem',
+    });
+
+    await webhookPost('manda um oi para assistente');
 
     // sendWhatsApp must only be called once — to reply to the owner (preview), not to the contact
     const calls = (sendWhatsApp as any).mock.calls;
@@ -346,8 +352,14 @@ describe('Webhook — SEND_TO (approval gate)', () => {
     expect(sentToContact).toBe(false);
   });
 
-  it('creates a Communication record with AWAITING_APPROVAL when SEND_TO is triggered', async () => {
-    await webhookPost('manda para assistente: olá tudo bem');
+  it('creates a Communication record with AWAITING_APPROVAL when SEND_MESSAGE is detected', async () => {
+    (classifyIntent as any).mockResolvedValue({
+      intent: 'SEND_MESSAGE',
+      contact_name: 'assistente',
+      message: 'olá tudo bem',
+    });
+
+    await webhookPost('manda um oi para assistente');
 
     expect(prisma.communication.create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -362,7 +374,13 @@ describe('Webhook — SEND_TO (approval gate)', () => {
   });
 
   it('replies to owner with a preview and confirmation instructions', async () => {
-    await webhookPost('manda para assistente: olá tudo bem');
+    (classifyIntent as any).mockResolvedValue({
+      intent: 'SEND_MESSAGE',
+      contact_name: 'assistente',
+      message: 'olá tudo bem',
+    });
+
+    await webhookPost('manda um oi para assistente');
 
     const sentText: string = (sendWhatsApp as any).mock.calls[0][1];
     expect(sentText).toContain('assistente');
@@ -372,7 +390,13 @@ describe('Webhook — SEND_TO (approval gate)', () => {
   });
 
   it('replies with error if contact is not found', async () => {
-    await webhookPost('manda para desconhecido: oi');
+    (classifyIntent as any).mockResolvedValue({
+      intent: 'SEND_MESSAGE',
+      contact_name: 'desconhecido',
+      message: 'oi',
+    });
+
+    await webhookPost('manda oi para o desconhecido');
 
     const sentText: string = (sendWhatsApp as any).mock.calls[0][1];
     expect(sentText).toContain('não encontrado');
@@ -563,14 +587,15 @@ describe('Webhook — CREATE_EVENT', () => {
     expect(sentText).toContain('1️⃣');
   });
 
-  it('retorna erro de parse quando LLM não detecta CREATE_EVENT', async () => {
+  it('cria tarefa (fallback) quando LLM não detecta CREATE_EVENT', async () => {
     (getToken as any).mockResolvedValue('fake-token');
     (classifyIntent as any).mockResolvedValue({ intent: 'UNKNOWN' });
+    (prisma.task.create as any).mockResolvedValue({ id: 't1', title: 'marca alguma coisa' });
 
     await webhookPost('marca alguma coisa');
 
     const sentText: string = (sendWhatsApp as any).mock.calls[0][1];
-    expect(sentText).toContain('❌');
+    expect(sentText).toContain('✅ Tarefa criada: "marca alguma coisa"');
   });
 });
 

--- a/apps/api/src/routes/webhook.ts
+++ b/apps/api/src/routes/webhook.ts
@@ -403,193 +403,12 @@ async function handleIncomingWhatsApp(
             break;
           }
 
-          // Alias not registered — fallback to CREATE_TASK logic
+          // Alias not registered — fallback to task creation
           const newTask = await prisma.task.create({
             data: { title: message_text, category: 'outros' },
           });
           responseText = `✅ Tarefa criada: "${newTask.title}"`;
         }
-        break;
-      }
-
-      case 'CREATE_EVENT': {
-        const calendarToken = await getToken();
-        if (!calendarToken) {
-          responseText = '❌ Calendário não configurado. Execute o OAuth bootstrap no servidor para habilitar agendamento via áudio.';
-          break;
-        }
-        const eventClassification = await classifyIntent(args?.rawText ?? '');
-        if (eventClassification.intent === 'CREATE_EVENT') {
-          const startISO = buildEventStartISO(eventClassification.date, eventClassification.time);
-          const comm = await prisma.communication.create({
-            data: {
-              provider: 'WHATSAPP',
-              type: 'DRAFT',
-              to: null,
-              body: null,
-              status: 'AWAITING_APPROVAL',
-              metadata: {
-                kind: 'CREATE_EVENT',
-                title: eventClassification.title,
-                start: startISO,
-                duration_min: eventClassification.duration_min,
-                sender_id,
-              },
-            },
-          });
-          await savePending(sender_id, comm.id);
-          responseText = eventPreview(eventClassification.title, startISO, eventClassification.duration_min);
-        } else {
-          responseText = `❌ Não entendi o evento. Tente: "marca reunião com João quinta às 15h"`;
-        }
-        break;
-      }
-
-      case 'CREATE_TASK': {
-        // Try LLM classification before creating a task
-        const classification = await classifyIntent(args?.rawText ?? '');
-
-        if (classification.intent === 'REGISTER_ALIAS') {
-          try {
-            await addAlias(classification.contact_name, classification.alias);
-            responseText = `✅ Registrado! Agora *${classification.alias}* = ${classification.contact_name}.`;
-          } catch {
-            responseText = `❌ Contato "${classification.contact_name}" não encontrado. Cadastre-o primeiro.`;
-          }
-          break;
-        }
-
-        if (classification.intent === 'CREATE_CONTACT') {
-          const alias = '/' + classification.contact_name.toLowerCase().replace(/\s+/g, '');
-          try {
-            await createContact(classification.contact_name, classification.phone, [alias], classification.owner_alias);
-            responseText = `✅ Contato *${classification.contact_name}* criado! Use ${alias} <msg> para mandar mensagem.`;
-          } catch {
-            responseText = `❌ Não consegui criar o contato. Verifique se o nome já existe.`;
-          }
-          break;
-        }
-
-        if (classification.intent === 'SET_OWNER_ALIAS') {
-          try {
-            await setOwnerAlias(classification.contact_name, classification.owner_alias);
-            responseText = `✅ Pronto! Agora nas mensagens para *${classification.contact_name}* você é *${classification.owner_alias}*.`;
-          } catch {
-            responseText = `❌ Contato "${classification.contact_name}" não encontrado.`;
-          }
-          break;
-        }
-
-        if (classification.intent === 'EDIT_CONTACT') {
-          try {
-            const updated = await updateContact(
-              classification.contact_name,
-              classification.field,
-              classification.new_value
-            );
-            responseText = `✅ Contato atualizado: ${updated.name}`;
-          } catch (err: any) {
-            if (err.code === 'P2002') {
-              responseText = `❌ Erro: Já existe um contato com esse nome ou alias.`;
-            } else {
-              responseText = `❌ Não encontrei nenhum contato com esse nome. Verifique com /contatos.`;
-            }
-          }
-          break;
-        }
-
-        if (classification.intent === 'DELETE_CONTACT') {
-          const identifier = classification.contact_identifier;
-          const contact = identifier.startsWith('/')
-            ? await findByAlias(identifier)
-            : await findByName(identifier);
-
-          if (!contact) {
-            responseText = `❌ Não encontrei nenhum contato com esse nome ou alias. Verifique com /contatos.`;
-            break;
-          }
-
-          const alias = contact.aliases[0] || '';
-          const formattedAlias = alias.startsWith('/') ? alias : `/${alias}`;
-
-          const comm = await prisma.communication.create({
-            data: {
-              provider: 'WHATSAPP',
-              type: 'DRAFT',
-              to: null,
-              body: null,
-              status: 'AWAITING_APPROVAL',
-              metadata: {
-                kind: 'DELETE_CONTACT',
-                contactId: contact.id,
-                contactName: contact.name,
-                sender_id,
-              },
-            },
-          });
-          await savePending(sender_id, comm.id);
-          responseText = deleteContactPreview(contact.name, formattedAlias, contact.phone);
-          break;
-        }
-
-        if (classification.intent === 'INTRODUCE_SELF') {
-          const contact = (await findByName(classification.contact_name)) || (await findByAlias(classification.contact_name));
-
-          if (!contact) {
-            responseText = `❌ Contato "${classification.contact_name}" não encontrado.`;
-            break;
-          }
-
-          const ownerAlias = contact.owner_alias || process.env.OWNER_NAME || 'Rafael';
-          const generatedMessage = await generateIntroduction(contact.name, classification.context, ownerAlias);
-
-          const comm = await prisma.communication.create({
-            data: {
-              provider: 'WHATSAPP',
-              type: 'DRAFT',
-              to: contact.phone,
-              body: generatedMessage,
-              status: 'AWAITING_APPROVAL',
-              metadata: { contactName: contact.name, sender_id },
-            },
-          });
-          await savePending(sender_id, comm.id);
-          responseText = `Entendi: Apresentação para ${contact.name}\n\n${draftPreview(contact.name, generatedMessage)}`;
-          break;
-        }
-
-        if (classification.intent === 'SEND_MESSAGE') {
-          responseText = await processSendMessage(
-            sender_id,
-            classification.contact_name,
-            classification.message,
-            'whatsapp.draft.llm'
-          );
-          break;
-        }
-
-        const taskTitle = args?.rawText || 'Sem título';
-        const newTask = await prisma.task.create({
-          data: {
-            title: taskTitle,
-            category: 'outros',
-          },
-        });
-
-        const reminder = await extractReminder(taskTitle, TIMEZONE);
-        if (reminder) {
-          await prisma.reminder.create({
-            data: {
-              task_id: newTask.id,
-              remind_at: new Date(reminder.remind_at),
-              channel: 'whatsapp',
-              status: 'SCHEDULED',
-            },
-          });
-        }
-
-        responseText = `✅ Tarefa criada: "${newTask.title}"`;
-
         break;
       }
 
@@ -619,14 +438,6 @@ async function handleIncomingWhatsApp(
         break;
       }
 
-      case 'SEND_TO': {
-        responseText = await processSendMessage(
-          sender_id,
-          args?.contactName ?? '',
-          args?.message ?? ''
-        );
-        break;
-      }
 
       case 'CONFIRM': {
         const commId = args?.communication_id ?? await getPending(sender_id);
@@ -759,7 +570,177 @@ async function handleIncomingWhatsApp(
       }
 
       case 'UNKNOWN': {
-        responseText = '❌ Não entendi. Use /comandos para ver a lista de comandos disponíveis.';
+        // Try LLM classification for any unknown command or plain text
+        const classification = await classifyIntent(args?.rawText ?? '');
+
+        if (classification.intent === 'REGISTER_ALIAS') {
+          try {
+            await addAlias(classification.contact_name, classification.alias);
+            responseText = `✅ Registrado! Agora *${classification.alias}* = ${classification.contact_name}.`;
+          } catch {
+            responseText = `❌ Contato "${classification.contact_name}" não encontrado. Cadastre-o primeiro.`;
+          }
+          break;
+        }
+
+        if (classification.intent === 'CREATE_CONTACT') {
+          const alias = '/' + classification.contact_name.toLowerCase().replace(/\s+/g, '');
+          try {
+            await createContact(classification.contact_name, classification.phone, [alias], classification.owner_alias);
+            responseText = `✅ Contato *${classification.contact_name}* criado! Use ${alias} <msg> para mandar mensagem.`;
+          } catch {
+            responseText = `❌ Não consegui criar o contato. Verifique se o nome já existe.`;
+          }
+          break;
+        }
+
+        if (classification.intent === 'SET_OWNER_ALIAS') {
+          try {
+            await setOwnerAlias(classification.contact_name, classification.owner_alias);
+            responseText = `✅ Pronto! Agora nas mensagens para *${classification.contact_name}* você é *${classification.owner_alias}*.`;
+          } catch {
+            responseText = `❌ Contato "${classification.contact_name}" não encontrado.`;
+          }
+          break;
+        }
+
+        if (classification.intent === 'EDIT_CONTACT') {
+          try {
+            const updated = await updateContact(
+              classification.contact_name,
+              classification.field,
+              classification.new_value
+            );
+            responseText = `✅ Contato atualizado: ${updated.name}`;
+          } catch (err: any) {
+            if (err.code === 'P2002') {
+              responseText = `❌ Erro: Já existe um contato com esse nome ou alias.`;
+            } else {
+              responseText = `❌ Não encontrei nenhum contato com esse nome. Verifique com /contatos.`;
+            }
+          }
+          break;
+        }
+
+        if (classification.intent === 'DELETE_CONTACT') {
+          const identifier = classification.contact_identifier;
+          const contact = identifier.startsWith('/')
+            ? await findByAlias(identifier)
+            : await findByName(identifier);
+
+          if (!contact) {
+            responseText = `❌ Não encontrei nenhum contato com esse nome ou alias. Verifique com /contatos.`;
+            break;
+          }
+
+          const alias = contact.aliases[0] || '';
+          const formattedAlias = alias.startsWith('/') ? alias : `/${alias}`;
+
+          const comm = await prisma.communication.create({
+            data: {
+              provider: 'WHATSAPP',
+              type: 'DRAFT',
+              to: null,
+              body: null,
+              status: 'AWAITING_APPROVAL',
+              metadata: {
+                kind: 'DELETE_CONTACT',
+                contactId: contact.id,
+                contactName: contact.name,
+                sender_id,
+              },
+            },
+          });
+          await savePending(sender_id, comm.id);
+          responseText = deleteContactPreview(contact.name, formattedAlias, contact.phone);
+          break;
+        }
+
+        if (classification.intent === 'INTRODUCE_SELF') {
+          const contact = (await findByName(classification.contact_name)) || (await findByAlias(classification.contact_name));
+
+          if (!contact) {
+            responseText = `❌ Contato "${classification.contact_name}" não encontrado.`;
+            break;
+          }
+
+          const ownerAlias = contact.owner_alias || process.env.OWNER_NAME || 'Rafael';
+          const generatedMessage = await generateIntroduction(contact.name, classification.context, ownerAlias);
+
+          const comm = await prisma.communication.create({
+            data: {
+              provider: 'WHATSAPP',
+              type: 'DRAFT',
+              to: contact.phone,
+              body: generatedMessage,
+              status: 'AWAITING_APPROVAL',
+              metadata: { contactName: contact.name, sender_id },
+            },
+          });
+          await savePending(sender_id, comm.id);
+          responseText = `Entendi: Apresentação para ${contact.name}\n\n${draftPreview(contact.name, generatedMessage)}`;
+          break;
+        }
+
+        if (classification.intent === 'SEND_MESSAGE') {
+          responseText = await processSendMessage(
+            sender_id,
+            classification.contact_name,
+            classification.message,
+            'whatsapp.draft.llm'
+          );
+          break;
+        }
+
+        if (classification.intent === 'CREATE_EVENT') {
+          const calendarToken = await getToken();
+          if (!calendarToken) {
+            responseText = '❌ Calendário não configurado. Execute o OAuth bootstrap no servidor para habilitar agendamento.';
+            break;
+          }
+          const startISO = buildEventStartISO(classification.date, classification.time);
+          const comm = await prisma.communication.create({
+            data: {
+              provider: 'WHATSAPP',
+              type: 'DRAFT',
+              to: null,
+              body: null,
+              status: 'AWAITING_APPROVAL',
+              metadata: {
+                kind: 'CREATE_EVENT',
+                title: classification.title,
+                start: startISO,
+                duration_min: classification.duration_min,
+                sender_id,
+              },
+            },
+          });
+          await savePending(sender_id, comm.id);
+          responseText = eventPreview(classification.title, startISO, classification.duration_min);
+          break;
+        }
+
+        const taskTitle = args?.rawText || 'Sem título';
+        const newTask = await prisma.task.create({
+          data: {
+            title: taskTitle,
+            category: 'outros',
+          },
+        });
+
+        const reminder = await extractReminder(taskTitle, TIMEZONE);
+        if (reminder) {
+          await prisma.reminder.create({
+            data: {
+              task_id: newTask.id,
+              remind_at: new Date(reminder.remind_at),
+              channel: 'whatsapp',
+              status: 'SCHEDULED',
+            },
+          });
+        }
+
+        responseText = `✅ Tarefa criada: "${newTask.title}"`;
         break;
       }
     }
@@ -848,10 +829,12 @@ router.post('/webhook/baileys-audio', upload.single('audio'), async (req, res) =
       const normalized = await normalizeAudioCommand(text);
       let finalNormalized = normalized;
 
-      // Passo 2: se for SEND_TO, buscar owner_alias específico do contato
-      const parsed = parseCommand(normalized);
-      if (parsed.intent === 'SEND_TO' && parsed.args?.contactName) {
-        const contact = await findByName(parsed.args.contactName);
+      // Passo 2: detectar se é um comando de envio para buscar owner_alias específico do contato
+      // O formato esperado do normalizeAudioCommand é "manda para <nome>: <mensagem>"
+      const audioSendMatch = /^manda para (.*?):/i.exec(normalized);
+      if (audioSendMatch) {
+        const contactName = audioSendMatch[1].trim();
+        const contact = await findByName(contactName);
         const contactAlias = contact?.owner_alias;
         const defaultAlias = process.env.OWNER_NAME ?? 'Rafael';
         if (contactAlias && contactAlias !== defaultAlias) {


### PR DESCRIPTION
Simplified commandParser.ts by removing natural language regexes for SEND_TO and CREATE_EVENT. The parser now only handles deterministic slash commands and numeric shortcuts, returning UNKNOWN for everything else. Centralized natural language intent handling in the webhook.ts UNKNOWN case, leveraging classifyIntent (LLM). Updated test suites to reflect the new architecture.

Fixes #81

---
*PR created automatically by Jules for task [11277002298926508886](https://jules.google.com/task/11277002298926508886) started by @rafaeltcosta86*