### PR TITLE
fix(pdlc): corrigir Stage Gate e adicionar invariante de workflows

### DIFF
--- a/.github/workflows/upstream-gate.yml
+++ b/.github/workflows/upstream-gate.yml
@@ -27,6 +27,13 @@ jobs:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
             const body = context.payload.comment.body.toLowerCase().trim();
+            const rawBody = context.payload.comment.body.trim();
+
+            // Comentários com headers markdown ou muito longos são análises do agente, não aprovações do PM
+            if (rawBody.includes('##') || rawBody.length > 500) {
+              console.log('Comentário com headers markdown ou muito longo — análise do agente. Ignorando.');
+              return;
+            }
 
             // Aprovação explícita ou seleção implícita de opção
             const approved = /\b(aprovado|approved|ok|lgtm|pode detalhar)\b/.test(body)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -262,6 +262,10 @@ Antes de iniciar qualquer implementação (feature, bugfix, refactor, docs):
 
 Só commitar direto em `main` se o usuário **explicitamente** pedir.
 
+### O que NÃO fazer
+
+- **Nunca modificar arquivos em `.github/workflows/`** — esses arquivos definem o pipeline PDLC (automação de board, QA Agent, Sentinel) e são de responsabilidade exclusiva do agente upstream (Claude Code). Alterações acidentais nos workflows quebram a automação de board, QA e deploys. Se uma feature precisar de mudança no workflow, sinalizar explicitamente ao usuário.
+
 ---
 
 ## Definition of Done — obrigatório para toda feature


### PR DESCRIPTION
## Summary

- **Stage Gate** (`upstream-gate.yml`): comentários com headers markdown (`##`) ou acima de 500 chars são ignorados — impede que análises longas do agente upstream disparem a transição `brainstorming → detalhando` ao conter palavras como "opção B"
- **Invariante de workflows** (`docs/architecture.md`): adiciona seção "O que NÃO fazer" proibindo agentes de implementação de modificar `.github/workflows/`

## Test plan

- [ ] Postar comentário longo com `##` headers na issue em `stage:brainstorming` → Stage Gate deve ignorar
- [ ] Postar comentário curto "aprovado" ou "opção B" → Stage Gate deve transicionar para `stage:detalhando`
- [ ] Verificar que `AGENTS.md` leva ao `docs/architecture.md` onde a invariante está documentada

🤖 Generated with [Claude Code](https://claude.com/claude-code)