### PR TITLE
fix(pdlc): destino de PR aberto + CODEOWNERS + protect-workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Arquivos de workflow requerem aprovação explícita do PM.
+# Agentes de implementação (Jules, etc.) nunca devem modificar esses arquivos.
+.github/workflows/ @rafaeltcosta86

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
-# Arquivos de workflow requerem aprovação explícita do PM.
-# Agentes de implementação (Jules, etc.) nunca devem modificar esses arquivos.
-.github/workflows/ @rafaeltcosta86
+# Todo o diretório .github/ requer aprovação explícita do PM.
+# Isso inclui workflows, CODEOWNERS e demais configurações de automação.
+# Agentes de implementação nunca devem modificar esses arquivos.
+.github/ @rafaeltcosta86

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -138,14 +138,14 @@ jobs:
                 projectId: process.env.PROJECT_ID,
                 itemId,
                 fieldId: process.env.STATUS_FIELD_ID,
-                value: { singleSelectOptionId: process.env.STATUS_CODE_REVIEW }
+                value: { singleSelectOptionId: process.env.STATUS_TESTES }
               });
             };
 
             // Sempre tentar mover o PR (caso esteja no board sem issue linkada)
             if (linkedIssues.length === 0) {
               await moveItem(pr.node_id).catch(() => {});
-              console.log(`PR #${prNumber} adicionado ao board em Code Review`);
+              console.log(`PR #${prNumber} adicionado ao board em 🧪 Testes`);
             }
 
             // Mover issues linkadas (independentemente de o PR estar no board)

--- a/.github/workflows/protect-workflows.yml
+++ b/.github/workflows/protect-workflows.yml
@@ -1,21 +1,27 @@
-name: Protect Workflows
+name: Protect .github
 
 on:
   pull_request:
     paths:
-      - '.github/workflows/**'
+      - '.github/**'
 
 jobs:
-  block-workflow-changes:
-    name: Bloquear alterações em workflows por agentes
+  block-github-changes:
+    name: Bloquear alterações em .github/ por agentes
     runs-on: ubuntu-latest
     steps:
-      - name: Falhar se PR toca arquivos de workflow
+      - name: Permitir PRs do PM, bloquear agentes
         run: |
-          echo "❌ Este PR modifica arquivos em .github/workflows/"
+          AUTHOR="${{ github.event.pull_request.user.login }}"
+          if [ "$AUTHOR" = "rafaeltcosta86" ]; then
+            echo "✅ PR do PM ($AUTHOR) — alteração em .github/ permitida."
+            exit 0
+          fi
+          echo "❌ Este PR modifica arquivos em .github/"
           echo ""
-          echo "Arquivos de workflow são de responsabilidade exclusiva do PM."
-          echo "Agentes de implementação não devem modificar o pipeline PDLC."
+          echo "Autor: $AUTHOR"
+          echo "O diretório .github/ (workflows, CODEOWNERS, etc.) é de responsabilidade"
+          echo "exclusiva do PM. Agentes de implementação não devem modificar essas configs."
           echo ""
-          echo "Se esta alteração é intencional, solicite ao PM que abra um PR separado."
+          echo "Se esta alteração é intencional, o PM deve abrir um PR separado."
           exit 1

--- a/.github/workflows/protect-workflows.yml
+++ b/.github/workflows/protect-workflows.yml
@@ -1,0 +1,21 @@
+name: Protect Workflows
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  block-workflow-changes:
+    name: Bloquear alterações em workflows por agentes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Falhar se PR toca arquivos de workflow
+        run: |
+          echo "❌ Este PR modifica arquivos em .github/workflows/"
+          echo ""
+          echo "Arquivos de workflow são de responsabilidade exclusiva do PM."
+          echo "Agentes de implementação não devem modificar o pipeline PDLC."
+          echo ""
+          echo "Se esta alteração é intencional, solicite ao PM que abra um PR separado."
+          exit 1


### PR DESCRIPTION
## Summary

- **`project-automation.yml`**: corrigir `move-card-on-pr-open` — usava `STATUS_CODE_REVIEW` como destino, pulando 🧪 Testes. Sequência correta: PR aberto → Testes → QA passa → Code Review.
- **`CODEOWNERS`**: atribui `.github/workflows/` ao PM (`@rafaeltcosta86`). Com "Require review from Code Owners" no branch protection, PRs de agentes que toquem workflows ficam bloqueados.
- **`protect-workflows.yml`**: workflow guard que falha no CI se qualquer PR modificar `.github/workflows/` — enforcement técnico independente de branch protection.

## Test plan

- [ ] Abrir PR com `Closes #99` → card deve ir para 🧪 Testes (não Code Review)
- [ ] PR do Jules que toque `.github/workflows/` → `protect-workflows` deve falhar no CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)